### PR TITLE
MySql does not allow you to set defaults on text types.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,8 @@ class User < ActiveRecord::Base
   def email_required?
     provider == 'email'
   end
+
+  def tokens
+    self[:tokens].blank? ? {} : self[:tokens]
+  end
 end

--- a/db/migrate/20140628234942_devise_token_auth_create_users.rb
+++ b/db/migrate/20140628234942_devise_token_auth_create_users.rb
@@ -41,7 +41,7 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration
       t.string :uid, :null => false, :default => ""
 
       ## Tokens
-      t.text :tokens, default: "{}"
+      t.text :tokens
 
       t.timestamps
     end


### PR DESCRIPTION
First thanks for putting all the time in to the gem.  I just finished writing my own authentication and found this.  I like your implementation a lot better than the janky one i wrote and have been playing around with this tonight.

MySql is throwing some errors when you run the migrations it seems to not like adding defaults to text blobs.  
