### PR TITLE
guard against MissingAttributeError during common ActiveRecord operations

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -157,6 +157,6 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def set_empty_token_hash
-    self.tokens ||= {}
+    self.tokens ||= {} if has_attribute?(:tokens)
   end
 end


### PR DESCRIPTION
This seems like the most correct thing to do until Rails differentiates between object decanting and object creation for after_initialize.

see also: http://www.tatvartha.com/2011/03/activerecordmissingattributeerror-missing-attribute-a-bug-or-a-features/
