### PR TITLE
fix(expiry): fix an issue where token expiration checks were too permissive

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -99,8 +99,8 @@ module DeviseTokenAuth::Concerns::User
       self.tokens[client_id]['expiry'] and
       self.tokens[client_id]['token'] and
 
-      # ensure that the token was created within the last two weeks
-      DateTime.strptime(self.tokens[client_id]['expiry'].to_s, '%s') > DeviseTokenAuth.token_lifespan.ago and
+      # ensure that the token has not yet expired
+      DateTime.strptime(self.tokens[client_id]['expiry'].to_s, '%s') > Time.now and
 
       # ensure that the token is valid
       BCrypt::Password.new(self.tokens[client_id]['token']) == token

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -37,6 +37,26 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'token expiry' do
+      before do
+        @user = users(:confirmed_email_user)
+        @user.skip_confirmation!
+        @user.save!
+
+        @auth_headers = @user.create_new_auth_token
+
+        @token     = @auth_headers['access-token']
+        @client_id = @auth_headers['client']
+      end
+
+      test 'should properly indicate whether token is current' do
+        assert @user.token_is_current?(@token, @client_id)
+        # we want to update the expiry without forcing a cleanup (see below)
+        @user.tokens[@client_id]['expiry'] = Time.now.to_i - 10.seconds
+        refute @user.token_is_current?(@token, @client_id)
+      end
+    end
+
     describe 'expired tokens are destroyed on save' do
       before do
         @user = users(:confirmed_email_user)


### PR DESCRIPTION
Looks like the expiration check in `token_is_current?` would have always passed. Let me know if there's something I'm missing here.
