### PR TITLE
fix(case-sensitivity): support devise case_insensitive_keys for session ...

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -20,8 +20,15 @@ module DeviseTokenAuth
         }, status: 401
       end
 
+      # honor devise configuration for case_insensitive_keys
+      if resource_class.case_insensitive_keys.include?(:email)
+        email = resource_params[:email].downcase
+      else
+        email = resource_params[:email]
+      end
+
       @resource = resource_class.where({
-        email: resource_params[:email],
+        email: email,
         provider: 'email'
       }).first
 
@@ -29,7 +36,7 @@ module DeviseTokenAuth
 
       if @resource
         @resource.send_reset_password_instructions({
-          email: resource_params[:email],
+          email: email,
           provider: 'email',
           redirect_url: params[:redirect_url],
           client_config: params[:config_name]
@@ -38,14 +45,14 @@ module DeviseTokenAuth
         if @resource.errors.empty?
           render json: {
             success: true,
-            message: "An email has been sent to #{@resource.email} containing "+
+            message: "An email has been sent to #{email} containing "+
               "instructions for resetting your password."
           }
         else
           errors = @resource.errors
         end
       else
-        errors = ["Unable to find user with email '#{resource_params[:email]}'."]
+        errors = ["Unable to find user with email '#{email}'."]
       end
 
       if errors

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -4,7 +4,13 @@ module DeviseTokenAuth
     before_filter :set_user_by_token, :only => [:destroy]
 
     def create
-      @resource = resource_class.find_by_email(resource_params[:email])
+      # honor devise configuration for case_insensitive_keys
+      if resource_class.case_insensitive_keys.include?(:email)
+        email = resource_params[:email].downcase
+      else
+        email = resource_params[:email]
+      end
+      @resource = resource_class.find_by_email(email)
 
       if @resource and valid_params? and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
         # create client id

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -15,94 +15,123 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
       end
 
       describe 'request password reset' do
-        before do
-          xhr :post, :create, {
-            email:        @resource.email,
-            redirect_url: @redirect_url
-          }
 
-          @mail = ActionMailer::Base.deliveries.last
-          @resource.reload
-
-          @mail_config_name  = CGI.unescape(@mail.body.match(/config=([^&]*)&/)[1])
-          @mail_redirect_url = CGI.unescape(@mail.body.match(/redirect_url=([^&]*)&/)[1])
-          @mail_reset_token  = @mail.body.match(/reset_password_token=(.*)\"/)[1]
-        end
-
-        test 'response should return success status' do
-          assert_equal 200, response.status
-        end
-
-        test 'action should send an email' do
-          assert @mail
-        end
-
-        test 'the email should be addressed to the user' do
-          assert_equal @mail.to.first, @resource.email
-        end
-
-        test 'the email body should contain a link with redirect url as a query param' do
-          assert_equal @redirect_url, @mail_redirect_url
-        end
-
-        test 'the client config name should fall back to "default"' do
-          assert_equal 'default', @mail_config_name
-        end
-
-        test 'the email body should contain a link with reset token as a query param' do
-          user = User.reset_password_by_token({
-            reset_password_token: @mail_reset_token
-          })
-
-          assert_equal user.id, @resource.id
-        end
-
-        describe 'password reset link failure' do
-          test 'request should not be authorized' do
-            assert_raises(ActionController::RoutingError) {
-              xhr :get, :edit, {
-                reset_password_token: 'bogus',
-                redirect_url: @mail_redirect_url
-              }
-            }
-          end
-        end
-
-        describe 'password reset link success' do
+        describe 'case-sensitive email' do
           before do
-            xhr :get, :edit, {
-              reset_password_token: @mail_reset_token,
-              redirect_url: @mail_redirect_url
+            xhr :post, :create, {
+              email:        @resource.email,
+              redirect_url: @redirect_url
             }
 
+            @mail = ActionMailer::Base.deliveries.last
             @resource.reload
 
-            raw_qs = response.location.split('?')[1]
-            @qs = Rack::Utils.parse_nested_query(raw_qs)
-
-            @client_id      = @qs["client_id"]
-            @expiry         = @qs["expiry"]
-            @reset_password = @qs["reset_password"]
-            @token          = @qs["token"]
-            @uid            = @qs["uid"]
+            @mail_config_name  = CGI.unescape(@mail.body.match(/config=([^&]*)&/)[1])
+            @mail_redirect_url = CGI.unescape(@mail.body.match(/redirect_url=([^&]*)&/)[1])
+            @mail_reset_token  = @mail.body.match(/reset_password_token=(.*)\"/)[1]
           end
 
-          test 'respones should have success redirect status' do
-            assert_equal 302, response.status
+          test 'response should return success status' do
+            assert_equal 200, response.status
           end
 
-          test 'response should contain auth params' do
-            assert @client_id
-            assert @expiry
-            assert @reset_password
-            assert @token
-            assert @uid
+          test 'action should send an email' do
+            assert @mail
           end
 
-          test 'response auth params should be valid' do
-            assert @resource.valid_token?(@token, @client_id)
+          test 'the email should be addressed to the user' do
+            assert_equal @mail.to.first, @resource.email
           end
+
+          test 'the email body should contain a link with redirect url as a query param' do
+            assert_equal @redirect_url, @mail_redirect_url
+          end
+
+          test 'the client config name should fall back to "default"' do
+            assert_equal 'default', @mail_config_name
+          end
+
+          test 'the email body should contain a link with reset token as a query param' do
+            user = User.reset_password_by_token({
+              reset_password_token: @mail_reset_token
+            })
+
+            assert_equal user.id, @resource.id
+          end
+
+          describe 'password reset link failure' do
+            test 'request should not be authorized' do
+              assert_raises(ActionController::RoutingError) {
+                xhr :get, :edit, {
+                  reset_password_token: 'bogus',
+                  redirect_url: @mail_redirect_url
+                }
+              }
+            end
+          end
+
+          describe 'password reset link success' do
+            before do
+              xhr :get, :edit, {
+                reset_password_token: @mail_reset_token,
+                redirect_url: @mail_redirect_url
+              }
+
+              @resource.reload
+
+              raw_qs = response.location.split('?')[1]
+              @qs = Rack::Utils.parse_nested_query(raw_qs)
+
+              @client_id      = @qs["client_id"]
+              @expiry         = @qs["expiry"]
+              @reset_password = @qs["reset_password"]
+              @token          = @qs["token"]
+              @uid            = @qs["uid"]
+            end
+
+            test 'respones should have success redirect status' do
+              assert_equal 302, response.status
+            end
+
+            test 'response should contain auth params' do
+              assert @client_id
+              assert @expiry
+              assert @reset_password
+              assert @token
+              assert @uid
+            end
+
+            test 'response auth params should be valid' do
+              assert @resource.valid_token?(@token, @client_id)
+            end
+          end
+
         end
+
+        describe 'case-insensitive email' do
+
+          before do
+            @resource_class = User
+            @request_params = {
+              email:        @resource.email.upcase,
+              redirect_url: @redirect_url
+            }
+          end
+
+          test 'response should return success status if configured' do
+            @resource_class.case_insensitive_keys = [:email]
+            xhr :post, :create, @request_params
+            assert_equal 200, response.status
+          end
+
+          test 'response should return failure status if not configured' do
+            @resource_class.case_insensitive_keys = []
+            xhr :post, :create, @request_params
+            assert_equal 400, response.status
+          end
+
+        end
+
       end
 
       describe "change password" do

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -82,6 +82,30 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
           assert @data['errors']
         end
       end
+
+      describe 'case-insensitive email' do
+
+        before do
+          @resource_class = User
+          @request_params = {
+            email: @existing_user.email.upcase,
+            password: 'secret123'
+          }
+        end
+
+        test "request should succeed if configured" do
+          @resource_class.case_insensitive_keys = [:email]
+          xhr :post, :create, @request_params
+          assert_equal 200, response.status
+        end
+
+        test "request should fail if not configured" do
+          @resource_class.case_insensitive_keys = []
+          xhr :post, :create, @request_params
+          assert_equal 401, response.status
+        end
+
+      end
     end
 
     describe "Unconfirmed user" do


### PR DESCRIPTION
...and password controllers

see also: https://github.com/plataformatec/devise/wiki/How-To:-Use-case-insensitive-emails

Prior to this, email would always have to match case exactly, regardless of any underlying devise configuration settings.

The spec diff looks worse than it is. Added a new nested describe block to test 200 vs 400 status codes without altering the before setup of the other specs.
