### PR TITLE
Use resource_class to override email confirmation.

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -21,7 +21,7 @@ module DeviseTokenAuth
 
       begin
         # override email confirmation, must be sent manually from ctrl
-        User.skip_callback("create", :after, :send_on_create_confirmation_instructions)
+        resource_class.skip_callback("create", :after, :send_on_create_confirmation_instructions)
         if @resource.save
 
           unless @resource.confirmed?


### PR DESCRIPTION
Hi @lynndylanhurley,

If you try to use devise_token_auth without a defined User class, you'll get a:

```
NameError (uninitialized constant DeviseTokenAuth::RegistrationsController::User):
    .bundle/bundler/gems/devise_token_auth-b43a36fd21c6/app/controllers/devise_token_auth/registrations_controller.rb:25:in `create'
```

because the `User.skip_callback("create", :after, :send_on_create_confirmation_instructions)`.

I changed it to use the generic `resource_class` and ran the test suite according to your instructions [here](https://github.com/lynndylanhurley/devise_token_auth/issues/44#issuecomment-59279954).

I didn't add any test because I believe this change is related to https://github.com/lynndylanhurley/devise_token_auth/commit/d56af20b44033070d260846e4a28a18437c744ca, but let me know if I should add the test for it.

Thanks
