### PR TITLE
Exclude devise modules

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -17,7 +17,7 @@ module DeviseTokenAuth
       end
 
       # success redirect url is required
-      if DeviseTokenAuth.modules.include?(:confirmable) && !params[:confirm_success_url]
+      if resource_class.devise_modules.include?(:confirmable) && !params[:confirm_success_url]
         return render json: {
           status: 'error',
           data:   @resource,
@@ -29,12 +29,14 @@ module DeviseTokenAuth
         # override email confirmation, must be sent manually from ctrl
         resource_class.skip_callback("create", :after, :send_on_create_confirmation_instructions)
         if @resource.save
+
           unless @resource.confirmed?
             # user will require email authentication
             @resource.send_confirmation_instructions({
               client_config: params[:config_name],
               redirect_url: params[:confirm_success_url]
             })
+
           else
             # email auth has been bypassed, authenticate user
             @client_id = SecureRandom.urlsafe_base64(nil, false)
@@ -74,6 +76,7 @@ module DeviseTokenAuth
 
     def update
       if @resource
+
         if @resource.update_attributes(account_update_params)
           render json: {
             status: 'success',

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -2,9 +2,12 @@ module DeviseTokenAuth::Concerns::User
   extend ActiveSupport::Concern
 
   included do
-    # Include default devise modules. Others available are:
-    # :confirmable, :lockable, :timeoutable and :omniauthable
-    devise *DeviseTokenAuth.modules
+    # Hack to check if devise is already enabled
+    unless self.method_defined?(:devise_modules)
+      devise :database_authenticatable, :registerable,
+          :recoverable, :rememberable, :trackable, :validatable,
+          :confirmable, :omniauthable
+    end
 
     serialize :tokens, JSON
 
@@ -185,7 +188,7 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def confirmed?
-    DeviseTokenAuth.modules.exclude?(:confirmable) || super
+    self.devise_modules.exclude?(:confirmable) || super
   end
 
   protected

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -12,31 +12,14 @@ module DeviseTokenAuth
   mattr_accessor :change_headers_on_each_request,
                  :token_lifespan,
                  :batch_request_buffer_throttle,
-                 :omniauth_prefix,
-                 :excluded_modules
+                 :omniauth_prefix
 
   self.change_headers_on_each_request = true
   self.token_lifespan                 = 2.weeks
   self.batch_request_buffer_throttle  = 5.seconds
   self.omniauth_prefix                = '/omniauth'
-  self.excluded_modules               = []
 
   def self.setup(&block)
     yield self
-  end
-
-  def self.modules
-    available_modules = [
-      :database_authenticatable,
-      :registerable,
-      :recoverable,
-      :rememberable,
-      :trackable,
-      :validatable,
-      :confirmable,
-      :omniauthable
-    ]
-
-    available_modules - excluded_modules
   end
 end

--- a/lib/generators/devise_token_auth/install_generator.rb
+++ b/lib/generators/devise_token_auth/install_generator.rb
@@ -30,6 +30,10 @@ module DeviseTokenAuth
         inclusion = "include DeviseTokenAuth::Concerns::User"
         unless parse_file_for_line(fname, inclusion)
           inject_into_file fname, after: "class #{user_class} < ActiveRecord::Base\n" do <<-'RUBY'
+  # Include default devise modules.
+  devise :database_authenticatable, :registerable,
+          :recoverable, :rememberable, :trackable, :validatable,
+          :confirmable, :omniauthable
   include DeviseTokenAuth::Concerns::User
           RUBY
           end

--- a/lib/generators/devise_token_auth/templates/user.rb
+++ b/lib/generators/devise_token_auth/templates/user.rb
@@ -1,3 +1,7 @@
 class <%= user_class %> < ActiveRecord::Base
+  # Include default devise modules.
+  devise :database_authenticatable, :registerable,
+          :recoverable, :rememberable, :trackable, :validatable,
+          :confirmable, :omniauthable
   include DeviseTokenAuth::Concerns::User
 end


### PR DESCRIPTION
Add a configuration option to exclude devise modules from the defaults.

Fixes https://github.com/lynndylanhurley/devise_token_auth/issues/78 https://github.com/lynndylanhurley/devise_token_auth/issues/80 https://github.com/lynndylanhurley/devise_token_auth/issues/60

@lynndylanhurley thoughts?
