### PR TITLE
Fix small error in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,9 +533,9 @@ class User < ActiveRecord::Base
 
   # notice this comes BEFORE the include statement below
   # also notice that :confirmable is not included in this block
-  devise :database_authenticatable, :confirmable,
-         :recoverable, :trackable, :validatable,
-         :registerable
+  devise :database_authenticatable, :recoverable,
+         :trackable, :validatable, :registerable,
+         :omniauthable
 
   # note that this include statement comes AFTER the devise block above
   include DeviseTokenAuth::Concerns::User
@@ -555,7 +555,7 @@ class User < ActiveRecord::Base
   # notice that :omniauthable is not included in this block
   devise :database_authenticatable, :confirmable,
          :recoverable, :trackable, :validatable,
-         :registerable, :omniauthable
+         :registerable
 
   include DeviseTokenAuth::Concerns::User
 end


### PR DESCRIPTION
Both examples about how to exclude modules still had the modules to be
disabled (:confirmable and :omniauthable respectively).
