### PR TITLE
Make default Warden scope changeable

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -38,7 +38,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     user = uid && rc.find_by_uid(uid)
 
     if user && user.valid_token?(@token, @client_id)
-      sign_in(:user, user, store: false, bypass: true)
+      sign_in(DeviseTokenAuth.scope, user, store: false, bypass: true)
       return @resource = user
     else
       # zero all values previously set values

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -60,7 +60,7 @@ module DeviseTokenAuth
       # don't send confirmation email!!!
       @resource.skip_confirmation!
 
-      sign_in(:user, @resource, store: false, bypass: false)
+      sign_in(DeviseTokenAuth.scope, @resource, store: false, bypass: false)
 
       @resource.save!
 

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -30,7 +30,7 @@ module DeviseTokenAuth
         }
         @resource.save
 
-        sign_in(:user, @resource, store: false, bypass: false)
+        sign_in(DeviseTokenAuth.scope, @resource, store: false, bypass: false)
 
         render json: {
           data: @resource.as_json(except: [

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -12,12 +12,14 @@ module DeviseTokenAuth
   mattr_accessor :change_headers_on_each_request,
                  :token_lifespan,
                  :batch_request_buffer_throttle,
-                 :omniauth_prefix
+                 :omniauth_prefix,
+                 :scope
 
   self.change_headers_on_each_request = true
   self.token_lifespan                 = 2.weeks
   self.batch_request_buffer_throttle  = 5.seconds
   self.omniauth_prefix                = '/omniauth'
+  self.scope                          = :user
 
   def self.setup(&block)
     yield self

--- a/lib/generators/devise_token_auth/templates/devise_token_auth.rb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth.rb
@@ -19,4 +19,7 @@ DeviseTokenAuth.setup do |config|
   # example, using the default '/omniauth', the github oauth2 provider will
   # redirect successful authentications to '/omniauth/github/callback'
   #config.omniauth_prefix = "/omniauth"
+
+  # Scope to be used by Warden. Defaults to :user
+  #config.scope = :user
 end


### PR DESCRIPTION
Hi!

I have been using devise_token_auth successfully in my app until I need to change model name from User to Account. I reconfigured all the things as needed, but my application started throwing CookieOverflow exception:
````
ActionDispatch::Cookies::CookieOverflow (ActionDispatch::Cookies::CookieOverflow):
  actionpack (4.1.6) lib/action_dispatch/middleware/cookies.rb:529:in `[]='
  actionpack (4.1.6) lib/action_dispatch/middleware/session/cookie_store.rb:110:in `set_cookie'
````
In debugger I see that the whole Account object being put to session under ``warden.user.user.key`` which results to cookie overflow. If model is User than only user id is kept in session. I've noticed that gem always uses :user scope (which forms that ``warden.user.user.key`` name)  when talking to Devise and when I change scope name to :account error is gone and everything works as expected. So I decided to make scope configurable

Please note that I'm kind of new to Rails, so I may be tackling the problem from the wrong angle.