### PR TITLE
Make expiry key symbolized

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -160,7 +160,7 @@ module DeviseTokenAuth::Concerns::User
 
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
-    expiry = self.tokens[client_id]['expiry'].to_s
+    expiry = self.tokens[client_id][:expiry].to_s
 
     return {
       "access-token" => token,


### PR DESCRIPTION
I'm currently getting a null expiry header,

https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/models/devise_token_auth/concerns/user.rb#L163

Changing it to a symbol fixed it, so i assumed that the same issue would occur for all places where we used ```self.tokens[client_id]['<key>']```.

Edit: Changing it everywhere broke the suite, so i changed it to just the expiry header.