### PR TITLE
Ak confirmable disabled allow password reset

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -66,9 +66,7 @@ module DeviseTokenAuth::Concerns::User
       opts[:client_config] ||= "default"
 
       if self.class.devise_modules.include?(:confirmable) 
-        if pending_reconfirmation?
-          opts[:to] = unconfirmed_email
-        end
+        opts[:to] = unconfirmed_email if pending_reconfirmation?
       else
         opts[:to] = email
       end

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -65,8 +65,10 @@ module DeviseTokenAuth::Concerns::User
       # fall back to "default" config name
       opts[:client_config] ||= "default"
 
-      if pending_reconfirmation?
-        opts[:to] = unconfirmed_email
+      if self.class.devise_modules.include?(:confirmable) 
+        if pending_reconfirmation?
+          opts[:to] = unconfirmed_email
+        end
       else
         opts[:to] = email
       end


### PR DESCRIPTION
It needs a test case, but I added a line that allows the password reset functionality to work when the User model is not :confirmable.