### PR TITLE
Ak confirmable disabled allow password reset

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -87,7 +87,7 @@ module DeviseTokenAuth
           expiry: expiry
         }
 
-        # ensure that user is confirmed is the User model is :confirmable
+        # ensure that user is confirmed if the User model is :confirmable
         if self.class.devise_modules.include?(:confirmable)
           @resource.skip_confirmation! unless @resource.confirmed_at
         end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -87,8 +87,10 @@ module DeviseTokenAuth
           expiry: expiry
         }
 
-        # ensure that user is confirmed
-        @resource.skip_confirmation! unless @resource.confirmed_at
+        # ensure that user is confirmed is the User model is :confirmable
+        if self.class.devise_modules.include?(:confirmable)
+          @resource.skip_confirmation! unless @resource.confirmed_at
+        end
 
         @resource.save!
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -66,9 +66,7 @@ module DeviseTokenAuth::Concerns::User
       opts[:client_config] ||= "default"
 
       if self.class.devise_modules.include?(:confirmable) 
-        if pending_reconfirmation?
-          opts[:to] = unconfirmed_email
-        end
+        opts[:to] = unconfirmed_email if pending_reconfirmation?
       else
         opts[:to] = email
       end

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -65,8 +65,10 @@ module DeviseTokenAuth::Concerns::User
       # fall back to "default" config name
       opts[:client_config] ||= "default"
 
-      if pending_reconfirmation?
-        opts[:to] = unconfirmed_email
+      if self.class.devise_modules.include?(:confirmable) 
+        if pending_reconfirmation?
+          opts[:to] = unconfirmed_email
+        end
       else
         opts[:to] = email
       end


### PR DESCRIPTION
Needs a test case (or two), but I added a line that allows the password reset functionality to work when the User model is not :confirmable. This came out of https://github.com/lynndylanhurley/devise_token_auth/issues/124.