### PR TITLE
Ignore 'extra' in Twitter auth response to avoid CookieOverflow. Fixes #145.

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -11,8 +11,9 @@ module DeviseTokenAuth
       devise_mapping = request.env['omniauth.params']['resource_class'].underscore.to_sym
       redirect_route = "/#{Devise.mappings[devise_mapping].as_json["path"]}/#{params[:provider]}/callback"
 
-      # preserve omniauth info for success route
-      session['dta.omniauth.auth'] = request.env['omniauth.auth']
+      # preserve omniauth info for success route. ignore 'extra' in twitter
+      # auth response to avoid CookieOverflow.
+      session['dta.omniauth.auth'] = request.env['omniauth.auth'].except('extra')
       session['dta.omniauth.params'] = request.env['omniauth.params']
 
       redirect_to redirect_route


### PR DESCRIPTION
This addresses #145.