### PR TITLE
Authenticating an existing Warden/Devise User

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -21,18 +21,25 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     # no default user defined
     return unless rc
 
-    # user has already been found and authenticated
-    return @resource if @resource and @resource.class == rc
-
     # parse header for values necessary for authentication
     uid        = request.headers['uid'] || params['uid']
     @token     = request.headers['access-token'] || params['access-token']
     @client_id = request.headers['client'] || params['client']
 
-    return false unless @token
-
     # client_id isn't required, set to 'default' if absent
     @client_id ||= 'default'
+
+    # check for an existing user, authenticated via warden/devise
+    devise_warden_user =  warden.user(rc.to_s.underscore.to_sym)
+    if devise_warden_user && devise_warden_user.tokens[@client_id].nil?
+      @resource = devise_warden_user
+      @resource.create_new_auth_token
+    end
+
+    # user has already been found and authenticated
+    return @resource if @resource and @resource.class == rc
+
+    return false unless @token
 
     # mitigate timing attacks by finding by uid instead of auth token
     user = uid && rc.find_by_uid(uid)


### PR DESCRIPTION
Yo!

Alright, so I *think* this will help with #120, #168,  & #196;  In the event an app uses devise for normal session authentication and would like to also authenticate users via `DeviseTokenAuth` then I think this will help support both strategies and ease the transition.   Small bit of interstitial code to check for the user in warden and, if they're missing authentication details, create a token for them and pass them through. Otherwise, the normal token auth strategy kicks in.

**I had a couple of questions that are worth mentioning before merging this in, if it feels like its on the right approach:**

1. I added a test in `DemoUserController` integration test.  Does that feel like a good place for it?

2. I unfortunately can't use this commit in our own project because we're still on Rails 4.1, lol. Still wanted to contribute! We definitely have plans to upgrade soon, but is there anyway to support this in any earlier version?  I suspect no, which is perfectly fine! Just more gas on the fire to get us to upgrade.  I was just curious if there was a way to allow any Rails 4.1 apps to use it.

3. Anything I missed? Let me know. I'll do the work. You're busy enough.

