### PR TITLE
Users with allowed unconfirmed access can now log in successfully.

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -24,7 +24,7 @@ module DeviseTokenAuth
         @resource = resource_class.where(q, q_value).first
       end
 
-      if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
+      if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
         # create client id
         @client_id = SecureRandom.urlsafe_base64(nil, false)
         @token     = SecureRandom.urlsafe_base64(nil, false)
@@ -41,7 +41,7 @@ module DeviseTokenAuth
           data: @resource.token_validation_response
         }
 
-      elsif @resource and not @resource.confirmed?
+      elsif @resource and not (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
         render json: {
           success: false,
           errors: [

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -28,3 +28,15 @@ unconfirmed_email_user:
   created_at:         '<%= timestamp %>'
   updated_at:         '<%= timestamp %>'
   encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
+  confirmation_sent_at: '<%= timestamp %>'
+
+<% @recent_unconfirmed_email = Faker::Internet.email %>
+<% recent_timestamp = DateTime.parse(1.day.ago.to_s).to_time.strftime("%F %T") %>
+recent_unconfirmed_email_user:
+  uid:                "<%= @recent_unconfirmed_email %>"
+  email:              "<%= @recent_unconfirmed_email %>"
+  provider:           'email'
+  created_at:         '<%= timestamp %>'
+  updated_at:         '<%= timestamp %>'
+  encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
+  confirmation_sent_at: '<%= recent_timestamp %>'


### PR DESCRIPTION
These changes allow unconfirmed users to log in, provided that the time is within the interval specified by allow_unconfirmed_access_for.