### PR TITLE
Return 422 (was 500) when empty body for sign up and account update

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -1,6 +1,8 @@
 module DeviseTokenAuth
   class RegistrationsController < DeviseTokenAuth::ApplicationController
     before_filter :set_user_by_token, :only => [:destroy, :update]
+    before_filter :validate_sign_up_params, :only => :create
+    before_filter :validate_account_update_params, :only => :update
     skip_after_filter :update_auth_header, :only => [:create, :destroy]
 
     def create
@@ -133,6 +135,23 @@ module DeviseTokenAuth
 
     def account_update_params
       params.permit(devise_parameter_sanitizer.for(:account_update))
+    end
+
+    private
+
+    def validate_sign_up_params
+      validate_post_data sign_up_params, 'Please submit proper sign up data in request body.'
+    end
+
+    def validate_account_update_params
+      validate_post_data account_update_params, 'Please submit proper account update data in request body.'
+    end
+
+    def validate_post_data which, message
+      render json: {
+         status: 'error',
+         errors: [message]
+      }, status: :unprocessable_entity if which.empty?
     end
   end
 end

--- a/test/controllers/devise_token_auth/registrations_controller_test.rb
+++ b/test/controllers/devise_token_auth/registrations_controller_test.rb
@@ -9,6 +9,32 @@ require 'test_helper'
 
 class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::IntegrationTest
   describe DeviseTokenAuth::RegistrationsController do
+    describe 'Validate non-empty body' do
+      before do
+        # need to post empty data
+        post '/auth', {}
+
+        @resource = assigns(:resource)
+        @data = JSON.parse(response.body)
+      end
+
+      test 'request should fail' do
+        assert_equal 422, response.status
+      end
+
+      test 'returns error message' do
+        assert_not_empty @data['errors']
+      end
+
+      test 'return error status' do
+        assert_equal 'error', @data['status']
+      end
+
+      test 'user should not have been saved' do
+        assert @resource.nil?
+      end
+    end
+
     describe "Successful registration" do
       before do
         @mails_sent = ActionMailer::Base.deliveries.count
@@ -413,6 +439,33 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
             assert_equal @new_operating_thetan, @existing_user.operating_thetan
             assert_equal @email.downcase, @existing_user.email
             assert_equal @email.downcase, @existing_user.uid
+          end
+        end
+
+        describe 'validate non-empty body' do
+          before do
+            # get the email so we can check it wasn't updated
+            @email = @existing_user.email
+            put '/auth', {}, @auth_headers
+
+            @data = JSON.parse(response.body)
+            @existing_user.reload
+          end
+
+          test 'request should fail' do
+            assert_equal 422, response.status
+          end
+
+          test 'returns error message' do
+            assert_not_empty @data['errors']
+          end
+
+          test 'return error status' do
+            assert_equal 'error', @data['status']
+          end
+
+          test 'user should not have been saved' do
+            assert_equal @email, @existing_user.email
           end
         end
 


### PR DESCRIPTION
Hello.

As mentioned on issue #203, currently DTA returns 500 error when an empty POST or PUT is made on the registration controller. For those using DTA for API authentication without control over REST clients, this may be an issue. I went ahead and made some changes. I think I can do some refactoring on the tests and also on the before filters, but wanted to check if the idea is welcomed before moving forward.

Thanks!