### PR TITLE
remove fragment sign ("#") from URLs without fragment

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -215,8 +215,7 @@ module DeviseTokenAuth::Concerns::User
     res = "#{uri.scheme}://#{uri.host}"
     res += ":#{uri.port}" if (uri.port and uri.port != 80 and uri.port != 443)
     res += "#{uri.path}" if uri.path
-    res += '#'
-    res += "#{uri.fragment}" if uri.fragment
+    res += "##{uri.fragment}" if uri.fragment
     res += "?#{params.to_query}"
 
     return res


### PR DESCRIPTION
the "#" sign existed on URLs before the query sign "?" which made rails believe there are no params in the url (e.g. ventory.com#?param1=value1&param2=value2 was recognized as the request for ventory.com without params.).
removing the "#" sign was necessary in case there is no fragment in the url.

Thanks