### PR TITLE
Ability to localize error message

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -225,7 +225,7 @@ module DeviseTokenAuth::Concerns::User
   # only validate unique email among users that registered by email
   def unique_email_user
     if provider == 'email' and self.class.where(provider: 'email', email: email).count > 0
-      errors.add(:email, "This email address is already in use")
+      errors.add(:email, :already_in_use, default: "This email address is already in use")
     end
   end
 


### PR DESCRIPTION
Gem users must have ability to localize error messages.
So to localize error, simply put your message in locale.yml with key 
activerecord.errors.models.{{model}}.attributes.email.already_in_use