### PR TITLE
Super block yield

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Please read the [issue reporting guidelines](#issue-reporting) before posting is
   * [Excluding Modules](#excluding-modules)
   * [Custom Controller Overrides](#custom-controller-overrides)
   * [Email Template Overrides](#email-template-overrides)
+  * [Passing blocks to Controllers](#passing-blocks-controllers)
 * [Issue Reporting Guidelines](#issue-reporting)
 * [FAQ](#faq)
 * [Conceptual Diagrams](#conceptual)
@@ -367,7 +368,7 @@ Note that if the model that you're trying to access isn't called `User`, the hel
 # app/controllers/test_controller.rb
 class TestController < ApplicationController
   before_action :authenticate_user!
-  
+
   def members_only
     render json: {
       data: {
@@ -476,7 +477,7 @@ This gem supports the use of multiple user models. One possible use case is to a
 1. Define the routes to be used by the `Admin` user within a [`devise_scope`](https://github.com/plataformatec/devise#configuring-routes).
 
   **Example**:
-  
+
   ~~~ruby
   Rails.application.routes.draw do
     # when using multiple models, controllers will default to the first available
@@ -499,7 +500,7 @@ This gem supports the use of multiple user models. One possible use case is to a
     end
   end
   ~~~
-  
+
 1. Configure any `Admin` restricted controllers. Controllers will now have access to the methods [described here](#methods):
   * `before_action: :authenticate_admin!`
   * `current_admin`
@@ -516,7 +517,7 @@ It is also possible to control access to multiple user types at the same time us
 class DemoGroupController < ApplicationController
   devise_token_auth_group :member, contains: [:user, :admin]
   before_action :authenticate_member!
-  
+
   def members_only
     render json: {
       data: {
@@ -598,7 +599,7 @@ end
 
 ## Custom Controller Overrides
 
-The built-in controllers can be overridden with your own custom controllers. 
+The built-in controllers can be overridden with your own custom controllers.
 
 For example, the default behavior of the [`validate_token`](https://github.com/lynndylanhurley/devise_token_auth/blob/8a33d25deaedb4809b219e557e82ec7ec61bf940/app/controllers/devise_token_auth/token_validations_controller.rb#L6) method of the [`TokenValidationController`](https://github.com/lynndylanhurley/devise_token_auth/blob/8a33d25deaedb4809b219e557e82ec7ec61bf940/app/controllers/devise_token_auth/token_validations_controller.rb) is to return the `User` object as json (sans password and token data). The following example shows how to override the `validate_token` action to include a model method as well.
 
@@ -666,6 +667,22 @@ These files may be edited to suit your taste.
 
 **Note:** if you choose to modify these templates, do not modify the `link_to` blocks unless you absolutely know what you are doing.
 
+## Passing blocks to RegistrationController
+
+If you simply want to add behaviour to the existing Registration controller, you can do so by creating a new controller that inherits from it, and override the `create`, `update` or `destroy` methods, and passing a block to super:
+
+```ruby
+class Custom::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  def create
+    super do |resource|
+      resource.add_something(extra)
+    end
+  end
+
+end
+```
+
 # Issue Reporting
 
 When posting issues, please include the following information to speed up the troubleshooting process:
@@ -708,7 +725,7 @@ Removing the `new` routes will require significant modifications to devise. If t
 
 ### I'm having trouble using this gem alongside [ActiveAdmin](http://activeadmin.info/)...
 
-For some odd reason, [ActiveAdmin](http://activeadmin.info/) extends from your own app's `ApplicationController`. This becomes a problem if you include the `DeviseTokenAuth::Concerns::SetUserByToken` concern in your app's `ApplicationController`. 
+For some odd reason, [ActiveAdmin](http://activeadmin.info/) extends from your own app's `ApplicationController`. This becomes a problem if you include the `DeviseTokenAuth::Concerns::SetUserByToken` concern in your app's `ApplicationController`.
 
 The solution is to use two separate `ApplicationController` classes - one for your API, and one for ActiveAdmin. Something like this:
 

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -44,6 +44,7 @@ module DeviseTokenAuth
         # override email confirmation, must be sent manually from ctrl
         resource_class.skip_callback("create", :after, :send_on_create_confirmation_instructions)
         if @resource.save
+          yield @resource if block_given?
 
           unless @resource.confirmed?
             # user will require email authentication
@@ -93,6 +94,7 @@ module DeviseTokenAuth
       if @resource
 
         if @resource.update_attributes(account_update_params)
+          yield @resource if block_given?
           render json: {
             status: 'success',
             data:   @resource.as_json
@@ -114,6 +116,7 @@ module DeviseTokenAuth
     def destroy
       if @resource
         @resource.destroy
+        yield @resource if block_given?
 
         render json: {
           status: 'success',

--- a/test/controllers/custom/custom_registrations_controller_test.rb
+++ b/test/controllers/custom/custom_registrations_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Custom::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+
+  describe Custom::RegistrationsController do
+
+    setup do
+      @create_params = {
+        email: Faker::Internet.email,
+        password: "secret123",
+        password_confirmation: "secret123",
+        confirm_success_url: Faker::Internet.url,
+        unpermitted_param: '(x_x)'
+      }
+
+      @existing_user = nice_users(:confirmed_email_user)
+      @auth_headers  = @existing_user.create_new_auth_token
+      @client_id     = @auth_headers['client']
+
+      # ensure request is not treated as batch request
+      age_token(@existing_user, @client_id)
+    end
+
+    test "yield resource to block on create success" do
+      post '/nice_user_auth', @create_params
+      assert @controller.create_block_called?, "create failed to yield resource to provided block"
+    end
+
+    test "yield resource to block on update success" do
+      put '/nice_user_auth', {
+        nickname: "Ol' Sunshine-face",
+      }, @auth_headers
+      assert @controller.update_block_called?, "update failed to yield resource to provided block"
+    end
+
+    test "yield resource to block on destroy success" do
+      delete '/nice_user_auth', @auth_headers
+      assert @controller.destroy_block_called?, "update failed to yield resource to provided block"
+    end
+
+  end
+
+end

--- a/test/dummy/app/controllers/custom/registrations_controller.rb
+++ b/test/dummy/app/controllers/custom/registrations_controller.rb
@@ -1,0 +1,33 @@
+class Custom::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  def create
+    super do |resource|
+      @create_block_called = true
+    end
+  end
+
+  def update
+    super do |resource|
+      @update_block_called = true
+    end
+  end
+
+  def destroy
+    super do |resource|
+      @destroy_block_called = true
+    end
+  end
+
+  def create_block_called?
+    @create_block_called == true
+  end
+
+  def update_block_called?
+    @update_block_called == true
+  end
+
+  def destroy_block_called?
+    @destroy_block_called == true
+  end
+
+end

--- a/test/dummy/app/models/nice_user.rb
+++ b/test/dummy/app/models/nice_user.rb
@@ -1,0 +1,7 @@
+class NiceUser < ActiveRecord::Base
+  # Include default devise modules.
+  devise :database_authenticatable, :registerable,
+          :recoverable, :rememberable, :trackable, :validatable,
+          :confirmable, :omniauthable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -19,6 +19,10 @@ Rails.application.routes.draw do
     token_validations:  'overrides/token_validations'
   }
 
+  mount_devise_token_auth_for 'NiceUser', at: 'nice_user_auth', controllers: {
+    registrations: 'custom/registrations'
+  }
+
   mount_devise_token_auth_for 'OnlyEmailUser', at: 'only_email_auth', skip: [:omniauth_callbacks]
 
   mount_devise_token_auth_for 'UnregisterableUser', at: 'unregisterable_user_auth', skip: [:registrations]

--- a/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
+++ b/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
@@ -1,0 +1,54 @@
+class DeviseTokenAuthCreateNiceUsers < ActiveRecord::Migration
+  def change
+    create_table(:nice_users) do |t|
+      ## Required
+      t.string :provider, :null => false
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, :default => 0, :null => false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :nickname
+      t.string :image
+      t.string :email
+
+      ## Tokens
+      t.text :tokens
+
+      t.timestamps
+    end
+
+    add_index :nice_users, :email
+    add_index :nice_users, [:uid, :provider],     :unique => true
+    add_index :nice_users, :reset_password_token, :unique => true
+    # add_index :nice_users, :confirmation_token,   :unique => true
+    # add_index :nice_users, :unlock_token,         :unique => true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141222053502) do
+ActiveRecord::Schema.define(version: 20150409095712) do
 
   create_table "evil_users", force: :cascade do |t|
     t.string   "email"
@@ -76,6 +76,35 @@ ActiveRecord::Schema.define(version: 20141222053502) do
   add_index "mangs", ["email"], name: "index_mangs_on_email"
   add_index "mangs", ["reset_password_token"], name: "index_mangs_on_reset_password_token", unique: true
   add_index "mangs", ["uid", "provider"], name: "index_mangs_on_uid_and_provider", unique: true
+
+  create_table "nice_users", force: :cascade do |t|
+    t.string   "provider",                            null: false
+    t.string   "uid",                    default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "email"
+    t.text     "tokens"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "nice_users", ["email"], name: "index_nice_users_on_email"
+  add_index "nice_users", ["reset_password_token"], name: "index_nice_users_on_reset_password_token", unique: true
+  add_index "nice_users", ["uid", "provider"], name: "index_nice_users_on_uid_and_provider", unique: true
 
   create_table "only_email_users", force: :cascade do |t|
     t.string   "provider",                        null: false

--- a/test/fixtures/nice_users.yml
+++ b/test/fixtures/nice_users.yml
@@ -1,0 +1,29 @@
+<% timestamp = DateTime.parse(2.weeks.ago.to_s).to_time.strftime("%F %T") %>
+<% @email = Faker::Internet.email %>
+confirmed_email_user:
+  uid:                 "<%= @email %>"
+  email:               "<%= @email %>"
+  provider:            'email'
+  confirmed_at:        '<%= timestamp %>'
+  created_at:          '<%= timestamp %>'
+  updated_at:          '<%= timestamp %>'
+  encrypted_password:  <%= User.new.send(:password_digest, 'secret123') %>
+
+<% @fb_email = Faker::Internet.email %>
+duplicate_email_facebook_user:
+  uid:                 "<%= Faker::Number.number(10) %>"
+  email:               "<%= @fb_email %>"
+  provider:            'facebook'
+  created_at:          '<%= timestamp %>'
+  updated_at:          '<%= timestamp %>'
+  confirmed_at:        '<%= timestamp %>'
+  encrypted_password:  <%= User.new.send(:password_digest, 'secret123') %>
+
+<% @unconfirmed_email = Faker::Internet.email %>
+unconfirmed_email_user:
+  uid:                 "<%= @unconfirmed_email %>"
+  email:               "<%= @unconfirmed_email %>"
+  provider:            'email'
+  created_at:          '<%= timestamp %>'
+  updated_at:          '<%= timestamp %>'
+  encrypted_password:  <%= User.new.send(:password_digest, 'secret123') %>


### PR DESCRIPTION
I often find myself wanting to make small additions to the `RegistrationsController` (such as adding a role to a just-created User), but find overriding the entire controller a little bit overkill when I simply want to _add_ behaviour.

In vanilla Devise you can make a controller that inherits from `RegistrationsController`, override the method  and simply pass a block to `super` like this:

```ruby
def create
  super do |resource|
    resource.add_role :cool_user
  end
end
```

Which I think is ideal for small additions like these. This PR implements block yielding in `RegistrationsController` (and though it could easily be extended to the other controllers, I thought I'd see what you make of this before going the whole hog on this).

And sorry if the tests are a little gross looking — I'm used to Rspec!
 