### PR TITLE
Super block yield (all controllers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Please read the [issue reporting guidelines](#issue-reporting) before posting is
   * [Using Multiple User Classes](#using-multiple-models)
   * [Excluding Modules](#excluding-modules)
   * [Custom Controller Overrides](#custom-controller-overrides)
-  * [Email Template Overrides](#email-template-overrides)
   * [Passing blocks to Controllers](#passing-blocks-controllers)
+  * [Email Template Overrides](#email-template-overrides)
 * [Issue Reporting Guidelines](#issue-reporting)
 * [FAQ](#faq)
 * [Conceptual Diagrams](#conceptual)
@@ -650,6 +650,24 @@ mount_devise_token_auth_for 'User', at: 'auth', controllers: {
 
 **Note:** Controller overrides must implement the expected actions of the controllers that they replace.
 
+## Passing blocks to Controllers
+
+It may be that you simply want to _add_ behavior to existing controllers without having to re-implement their behavior completely. In this case, you can do so by creating a new controller that inherits from any of DeviseTokenAuth's controllers, overriding whichever methods you'd like to add behavior to by  passing a block to `super`:
+
+```ruby
+class Custom::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  def create
+    super do |resource|
+      resource.do_something(extra)
+    end
+  end
+
+end
+```
+
+Your block will be performed just before the controller would usually render a successful response.
+
 ## Email Template Overrides
 
 You will probably want to override the default email templates for email sign-up and password-reset confirmation. Run the following command to copy the email templates into your app:
@@ -666,22 +684,6 @@ This will create two new files:
 These files may be edited to suit your taste.
 
 **Note:** if you choose to modify these templates, do not modify the `link_to` blocks unless you absolutely know what you are doing.
-
-## Passing blocks to RegistrationController
-
-If you simply want to add behaviour to the existing Registration controller, you can do so by creating a new controller that inherits from it, and override the `create`, `update` or `destroy` methods, and passing a block to super:
-
-```ruby
-class Custom::RegistrationsController < DeviseTokenAuth::RegistrationsController
-
-  def create
-    super do |resource|
-      resource.add_something(extra)
-    end
-  end
-
-end
-```
 
 # Issue Reporting
 

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -17,6 +17,8 @@ module DeviseTokenAuth
 
         @resource.save!
 
+        yield if block_given?
+
         redirect_to(@resource.build_auth_url(params[:redirect_url], {
           token:                        token,
           client_id:                    client_id,

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -69,6 +69,8 @@ module DeviseTokenAuth
 
       @resource.save!
 
+      yield if block_given?
+
       # render user info to javascript postMessage communication window
       render :layout => "layouts/omniauth_response", :template => "devise_token_auth/omniauth_success"
     end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -57,6 +57,7 @@ module DeviseTokenAuth
       error_status = 400
 
       if @resource
+        yield if block_given?
         @resource.send_reset_password_instructions({
           email: email,
           provider: 'email',
@@ -108,6 +109,7 @@ module DeviseTokenAuth
         @resource.skip_confirmation! unless @resource.confirmed_at
 
         @resource.save!
+        yield if block_given?
 
         redirect_to(@resource.build_auth_url(params[:redirect_url], {
           token:          token,
@@ -147,6 +149,7 @@ module DeviseTokenAuth
       end
 
       if @resource.update_attributes(password_resource_params)
+        yield if block_given?
         return render json: {
           success: true,
           data: {

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -37,6 +37,8 @@ module DeviseTokenAuth
 
         sign_in(:user, @resource, store: false, bypass: false)
 
+        yield if block_given?
+
         render json: {
           data: @resource.token_validation_response
         }
@@ -67,6 +69,8 @@ module DeviseTokenAuth
       if user and client_id and user.tokens[client_id]
         user.tokens.delete(client_id)
         user.save!
+
+        yield if block_given?
 
         render json: {
           success:true

--- a/app/controllers/devise_token_auth/token_validations_controller.rb
+++ b/app/controllers/devise_token_auth/token_validations_controller.rb
@@ -6,6 +6,7 @@ module DeviseTokenAuth
     def validate_token
       # @resource will have been set by set_user_token concern
       if @resource
+        yield if block_given?
         render json: {
           success: true,
           data: @resource.token_validation_response

--- a/test/controllers/custom/custom_confirmations_controller_test.rb
+++ b/test/controllers/custom/custom_confirmations_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Custom::ConfirmationsControllerTest < ActionController::TestCase
+
+  describe Custom::ConfirmationsController do
+
+    before do
+      @redirect_url = Faker::Internet.url
+      @new_user = users(:unconfirmed_email_user)
+      @new_user.send_confirmation_instructions({
+        redirect_url: @redirect_url
+      })
+      @mail          = ActionMailer::Base.deliveries.last
+      @token         = @mail.body.match(/confirmation_token=([^&]*)&/)[1]
+      @client_config = @mail.body.match(/config=([^&]*)&/)[1]
+
+      get :show, {confirmation_token: @token, redirect_url: @redirect_url}
+    end
+
+    test "yield resource to block on show success" do
+      assert @controller.show_block_called?, "show failed to yield resource to provided block"
+    end
+
+  end
+
+end

--- a/test/controllers/custom/custom_omniauth_callbacks_controller_test.rb
+++ b/test/controllers/custom/custom_omniauth_callbacks_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Custom::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+
+  describe Custom::OmniauthCallbacksController do
+
+    setup do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new({
+        :provider => 'facebook',
+        :uid => '123545',
+        :info => {
+          name: 'swong',
+          email: 'swongsong@yandex.ru'
+        }
+      })
+    end
+
+    test "yield resource to block on omniauth_sucess success" do
+      @redirect_url = "http://ng-token-auth.dev/"
+      get_via_redirect '/nice_user_auth/facebook', {
+        auth_origin_url: @redirect_url
+      }
+      assert @controller.omniauth_success_block_called?, "omniauth_success failed to yield resource to provided block"
+    end
+
+  end
+
+end

--- a/test/controllers/custom/custom_passwords_controller_test.rb
+++ b/test/controllers/custom/custom_passwords_controller_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class Custom::PasswordsControllerTest < ActionController::TestCase
+
+  describe Custom::PasswordsController do
+
+    before do
+      @resource = users(:confirmed_email_user)
+      @redirect_url = 'http://ng-token-auth.dev'
+    end
+
+    test "yield resource to block on create success" do
+      post :create, {
+        email:        @resource.email,
+        redirect_url: @redirect_url
+      }
+
+      @mail = ActionMailer::Base.deliveries.last
+      @resource.reload
+
+      @mail_config_name  = CGI.unescape(@mail.body.match(/config=([^&]*)&/)[1])
+      @mail_redirect_url = CGI.unescape(@mail.body.match(/redirect_url=([^&]*)&/)[1])
+      @mail_reset_token  = @mail.body.match(/reset_password_token=(.*)\"/)[1]
+
+      assert @controller.create_block_called?, "create failed to yield resource to provided block"
+    end
+
+    test "yield resource to block on edit success" do
+      @resource = users(:unconfirmed_email_user)
+      @redirect_url = 'http://ng-token-auth.dev'
+
+      xhr :post, :create, {
+        email:        @resource.email,
+        redirect_url: @redirect_url
+      }
+
+      @mail = ActionMailer::Base.deliveries.last
+      @resource.reload
+
+      @mail_config_name  = CGI.unescape(@mail.body.match(/config=([^&]*)&/)[1])
+      @mail_redirect_url = CGI.unescape(@mail.body.match(/redirect_url=([^&]*)&/)[1])
+      @mail_reset_token  = @mail.body.match(/reset_password_token=(.*)\"/)[1]
+
+      xhr :get, :edit, {
+        reset_password_token: @mail_reset_token,
+        redirect_url: @mail_redirect_url
+      }
+
+      @resource.reload
+      assert @controller.edit_block_called?, "edit failed to yield resource to provided block"
+    end
+
+    test "yield resource to block on update success" do
+      @auth_headers = @resource.create_new_auth_token
+      request.headers.merge!(@auth_headers)
+      @new_password = Faker::Internet.password
+      put :update, {
+        password: @new_password,
+        password_confirmation: @new_password
+      }
+      assert @controller.update_block_called?, "update failed to yield resource to provided block"
+    end
+
+  end
+
+end

--- a/test/controllers/custom/custom_registrations_controller_test.rb
+++ b/test/controllers/custom/custom_registrations_controller_test.rb
@@ -35,7 +35,7 @@ class Custom::RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     test "yield resource to block on destroy success" do
       delete '/nice_user_auth', @auth_headers
-      assert @controller.destroy_block_called?, "update failed to yield resource to provided block"
+      assert @controller.destroy_block_called?, "destroy failed to yield resource to provided block"
     end
 
   end

--- a/test/controllers/custom/custom_sessions_controller_test.rb
+++ b/test/controllers/custom/custom_sessions_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Custom::SessionsControllerTest < ActionController::TestCase
+
+  describe Custom::SessionsController do
+
+    before do
+      @existing_user = users(:confirmed_email_user)
+      @existing_user.skip_confirmation!
+      @existing_user.save!
+    end
+
+    test "yield resource to block on create success" do
+      post :create, {
+        email: @existing_user.email,
+        password: 'secret123'
+      }
+      assert @controller.create_block_called?, "create failed to yield resource to provided block"
+    end
+
+    test "yield resource to block on destroy success" do
+      @auth_headers = @existing_user.create_new_auth_token
+      request.headers.merge!(@auth_headers)
+      delete :destroy, format: :json
+      assert @controller.destroy_block_called?, "destroy failed to yield resource to provided block"
+    end
+
+  end
+
+end

--- a/test/controllers/custom/custom_token_validations_controller_test.rb
+++ b/test/controllers/custom/custom_token_validations_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Custom::TokenValidationsControllerTest < ActionDispatch::IntegrationTest
+
+  describe Custom::TokenValidationsController do
+
+    before do
+      @resource = nice_users(:confirmed_email_user)
+      @resource.skip_confirmation!
+      @resource.save!
+
+      @auth_headers = @resource.create_new_auth_token
+
+      @token     = @auth_headers['access-token']
+      @client_id = @auth_headers['client']
+      @expiry    = @auth_headers['expiry']
+
+      # ensure that request is not treated as batch request
+      age_token(@resource, @client_id)
+    end
+
+    test "yield resource to block on validate_token success" do
+      get '/nice_user_auth/validate_token', {}, @auth_headers
+      assert @controller.validate_token_block_called?, "validate_token failed to yield resource to provided block"
+    end
+
+  end
+
+end

--- a/test/dummy/app/controllers/custom/confirmations_controller.rb
+++ b/test/dummy/app/controllers/custom/confirmations_controller.rb
@@ -1,0 +1,13 @@
+class Custom::ConfirmationsController < DeviseTokenAuth::ConfirmationsController
+
+  def show
+    super do |resource|
+      @show_block_called = true
+    end
+  end
+
+  def show_block_called?
+    @show_block_called == true
+  end
+
+end

--- a/test/dummy/app/controllers/custom/omniauth_callbacks_controller.rb
+++ b/test/dummy/app/controllers/custom/omniauth_callbacks_controller.rb
@@ -1,0 +1,13 @@
+class Custom::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksController
+
+  def omniauth_success
+    super do |resource|
+      @omniauth_success_block_called = true
+    end
+  end
+
+  def omniauth_success_block_called?
+    @omniauth_success_block_called == true
+  end
+
+end

--- a/test/dummy/app/controllers/custom/passwords_controller.rb
+++ b/test/dummy/app/controllers/custom/passwords_controller.rb
@@ -1,0 +1,35 @@
+class Custom::PasswordsController < DeviseTokenAuth::PasswordsController
+
+  def create
+    super do |resource|
+      @create_block_called = true
+    end
+  end
+
+  def edit
+    super do |resource|
+      @edit_block_called = true
+    end
+  end
+
+  def update
+    super do |resource|
+      @update_block_called = true
+    end
+  end
+
+  def create_block_called?
+    @create_block_called == true
+  end
+
+  def edit_block_called?
+    @edit_block_called == true
+  end
+
+  def update_block_called?
+    @update_block_called == true
+  end
+
+
+
+end

--- a/test/dummy/app/controllers/custom/sessions_controller.rb
+++ b/test/dummy/app/controllers/custom/sessions_controller.rb
@@ -1,0 +1,23 @@
+class Custom::SessionsController < DeviseTokenAuth::SessionsController
+
+  def create
+    super do |resource|
+      @create_block_called = true
+    end
+  end
+
+  def destroy
+    super do |resource|
+      @destroy_block_called = true
+    end
+  end
+
+  def create_block_called?
+    @create_block_called == true
+  end
+
+  def destroy_block_called?
+    @destroy_block_called == true
+  end
+
+end

--- a/test/dummy/app/controllers/custom/token_validations_controller.rb
+++ b/test/dummy/app/controllers/custom/token_validations_controller.rb
@@ -1,0 +1,13 @@
+class Custom::TokenValidationsController < DeviseTokenAuth::TokenValidationsController
+
+  def validate_token
+    super do |resource|
+      @validate_token_block_called = true
+    end
+  end
+
+  def validate_token_block_called?
+    @validate_token_block_called == true
+  end
+
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -20,7 +20,12 @@ Rails.application.routes.draw do
   }
 
   mount_devise_token_auth_for 'NiceUser', at: 'nice_user_auth', controllers: {
-    registrations: 'custom/registrations'
+    registrations: 'custom/registrations',
+    confirmations: 'custom/confirmations',
+    passwords: 'custom/passwords',
+    sessions: 'custom/sessions',
+    token_validations: 'custom/token_validations',
+    omniauth_callbacks: 'custom/omniauth_callbacks'
   }
 
   mount_devise_token_auth_for 'OnlyEmailUser', at: 'only_email_auth', skip: [:omniauth_callbacks]


### PR DESCRIPTION
This expands on #207 by introducing block yielding to all of DeviseTokenAuth's controllers, allowing you to add behaviour to any controller's methods without having to reimplement the whole thing, like so:

```ruby
class Custom::RegistrationsController < DeviseTokenAuth::RegistrationsController

  def create
    super do |resource|
      resource.do_something(extra)
    end
  end

end
```

Please let me know if I've missed anything. I also didn't add block yielding to `OmniAuthCallbacksController`'s `redirect_callbacks`, as I'm not sure whether you'd _want_ to mess around in there. 

Have a good weekend!