### PR TITLE
URI fragment should appear at the end of URL

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -212,16 +212,14 @@ module DeviseTokenAuth::Concerns::User
   protected
 
 
-  # NOTE: ensure that fragment comes AFTER querystring for proper $location
-  # parsing using AngularJS.
   def generate_url(url, params = {})
     uri = URI(url)
 
     res = "#{uri.scheme}://#{uri.host}"
     res += ":#{uri.port}" if (uri.port and uri.port != 80 and uri.port != 443)
     res += "#{uri.path}" if uri.path
-    res += "##{uri.fragment}" if uri.fragment
     res += "?#{params.to_query}"
+    res += "##{uri.fragment}" if uri.fragment
 
     return res
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -86,5 +86,13 @@ class UserTest < ActiveSupport::TestCase
         assert @resource.tokens[@new_auth_headers["client"]]
       end
     end
+
+    describe "#generate_url" do
+      test 'URI fragment should appear at the end of URL' do
+        params = {client_id: 123}
+        url = 'http://example.com#fragment'
+        assert_equal @resource.send(:generate_url, url, params), "http://example.com?client_id=123#fragment"
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi, thanks for this project !

as I mention in https://github.com/lynndylanhurley/devise_token_auth/issues/213 the params in the query string for the `redirect_url` are not sent to the server due to the URI fragment.

according to the [RFC](http://tools.ietf.org/html/rfc3986#section-4.1) fragment should be at the end of the URL

more info: http://en.wikipedia.org/wiki/Fragment_identifier#Examples

not sure how Angular handle this, but I found: https://scotch.io/quick-tips/pretty-urls-in-angularjs-removing-the-hashtag