### PR TITLE
fix(sessions controller): call reset_session on destroy

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -2,6 +2,7 @@
 module DeviseTokenAuth
   class SessionsController < DeviseTokenAuth::ApplicationController
     before_filter :set_user_by_token, :only => [:destroy]
+    after_action :reset_session, :only => [:destroy]
 
     def create
       # Check

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -90,6 +90,8 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
       describe 'authed user sign out' do
         before do
+          def @controller.reset_session_called; @reset_session_called == true; end
+          def @controller.reset_session; @reset_session_called = true; end
           @auth_headers = @existing_user.create_new_auth_token
           request.headers.merge!(@auth_headers)
           xhr :delete, :destroy, format: :json
@@ -102,6 +104,10 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
         test "token was destroyed" do
           @existing_user.reload
           refute @existing_user.tokens[@auth_headers["client"]]
+        end
+
+        test "session was destroyed" do
+          assert_equal true, @controller.reset_session_called
         end
       end
 


### PR DESCRIPTION
I started using omniauth, which required me to enable rails sessions.  I noticed that the session was not getting killed when I logged out.  This should fix it.