### PR TITLE
feat(ominauth): support json-formatted values in omniauth callback. 

### DIFF
--- a/app/views/devise_token_auth/omniauth_success.html.erb
+++ b/app/views/devise_token_auth/omniauth_success.html.erb
@@ -1,5 +1,5 @@
 <% @resource.as_json.each do |attr, val| %>
-  "<%= attr %>": "<%= val %>",
+    "<%= attr %>": <%= val.to_json.html_safe %>,
 <% end %>
 
 "auth_token": "<%= @token %>",

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -60,16 +60,18 @@ class OmniauthTest < ActionDispatch::IntegrationTest
       test 'response contains all serializable attributes for user' do
         post_message = JSON.parse(/postMessage\((?<data>.*), '\*'\);/m.match(response.body)[:data])
 
-        assert post_message["id"]
-        assert post_message["email"]
-        assert post_message["uid"]
-        assert post_message["name"]
-        assert post_message["favorite_color"]
-        assert post_message["message"]
-        assert post_message["client_id"]
+
+        ['id', 'email', 'uid', 'name', 
+          'favorite_color', 'tokens', 'password'
+        ].each do |key|
+            assert_equal post_message[key], @resource.as_json[key], "Unexpected value for #{key.inspect}"
+        end
+        
+        assert_equal "deliverCredentials", post_message["message"]
         assert post_message["auth_token"]
-        refute post_message["tokens"]
-        refute post_message["password"]
+        assert post_message["client_id"]
+        assert post_message["expiry"]
+        assert post_message["config"]
       end
 
       test 'session vars have been cleared' do


### PR DESCRIPTION
Fixes #221

This is potentially a breaking change.  For example, nil values used to be rendered as an empty string, but will now render as undefined.

We needed it because we have some values in there that are arrays.