### PR TITLE
fix(session#new): fix unhandled 500 when logging in with valid user and bad password

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -14,7 +14,6 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
   # user auth
   def set_user_by_token(mapping=nil)
-
     # determine target authentication class
     rc = resource_class(mapping)
 
@@ -39,6 +38,12 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     # user has already been found and authenticated
     return @resource if @resource and @resource.class == rc
 
+    # ensure we clear the client_id
+    if !@token
+      @client_id = nil
+      return
+    end
+
     return false unless @token
 
     # mitigate timing attacks by finding by uid instead of auth token
@@ -49,13 +54,13 @@ module DeviseTokenAuth::Concerns::SetUserByToken
       return @resource = user
     else
       # zero all values previously set values
+      @client_id = nil
       return @resource = nil
     end
   end
 
 
   def update_auth_header
-
     # cannot save object if model has invalid params
     return unless @resource and @resource.valid? and @client_id
 

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -136,6 +136,36 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
         end
       end
 
+      describe 'failure with bad password when change_headers_on_each_request false' do
+        before do
+          DeviseTokenAuth.change_headers_on_each_request = false
+
+          # accessing current_user calls through set_user_by_token, 
+          # which initializes client_id
+          @controller.current_user
+
+          xhr :post, :create, {
+            email: @existing_user.email,
+            password: 'bogus'
+          }
+
+          @resource = assigns(:resource)
+          @data = JSON.parse(response.body)
+        end
+
+        test "request should fail" do
+          assert_equal 401, response.status
+        end
+
+        test "response should contain errors" do
+          assert @data['errors']
+        end
+
+        after do
+            DeviseTokenAuth.change_headers_on_each_request = true
+        end
+      end
+
       describe 'case-insensitive email' do
 
         before do


### PR DESCRIPTION
When token rotation is disabled, and the devise @resource is accessed within a before_filter, incorrect login credentials for an existing account can fail ungracefully causing a 500 server error instead of the expected 401. This is because both the @resource and @client_id remain set, despite falling through the failure criteria in `set_user_by_token`. As these instance variables persist, they allow the after_filter update_auth_header to continue to execute unexpectedly, calling  `auth_header = @resource.build_auth_header(@token, @client_id)`. This then triggers a null-ref in build_auth_header.
