### PR TITLE
fix(email-validation): Update in-use email validation message during registration to allow full_message use

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -225,7 +225,7 @@ module DeviseTokenAuth::Concerns::User
   # only validate unique email among users that registered by email
   def unique_email_user
     if provider == 'email' and self.class.where(provider: 'email', email: email).count > 0
-      errors.add(:email, :already_in_use, default: "This email address is already in use")
+      errors.add(:email, :already_in_use, default: "address is already in use")
     end
   end
 


### PR DESCRIPTION
Currently, if you have an email validation error during registration, you get a `full_message` response of "Email This Email address is already in use" and so you cannot simply regurgitate that as a client-facing error. This is because `full_message` construction takes the field name and prepends it to the default devise messaging. 

While this commit results in more abbreviated messaging, it allows `full_messages` to be used across the board without any additional programmatic work. If this message is not ideal, I believe it can still be modified through devise translation configuration: http://stackoverflow.com/a/12435725/824966