### PR TITLE
feat(omniauth callback): indicate if a new record was created

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -25,6 +25,7 @@ module DeviseTokenAuth
         uid:      auth_hash['uid'],
         provider: auth_hash['provider']
       }).first_or_initialize
+      @new_record = @resource.new_record?
 
       # create token info
       @client_id = SecureRandom.urlsafe_base64(nil, false)

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -25,7 +25,7 @@ module DeviseTokenAuth
         uid:      auth_hash['uid'],
         provider: auth_hash['provider']
       }).first_or_initialize
-      @new_record = @resource.new_record?
+      @oauth_registration = @resource.new_record?
 
       # create token info
       @client_id = SecureRandom.urlsafe_base64(nil, false)
@@ -33,13 +33,15 @@ module DeviseTokenAuth
       @expiry    = (Time.now + DeviseTokenAuth.token_lifespan).to_i
       @config    = omniauth_params['config_name']
 
-      @auth_origin_url = generate_url(omniauth_params['auth_origin_url'], {
+      auth_origin_url_params = {
         token:     @token,
         client_id: @client_id,
         uid:       @resource.uid,
         expiry:    @expiry,
         config:    @config
-      })
+      }
+      auth_origin_url_params.merge!(oauth_registration: true) if @oauth_registration
+      @auth_origin_url = generate_url(omniauth_params['auth_origin_url'], auth_origin_url_params)
 
       # set crazy password for new oauth users. this is only used to prevent
       # access via email sign-in.

--- a/app/views/devise_token_auth/omniauth_success.html.erb
+++ b/app/views/devise_token_auth/omniauth_success.html.erb
@@ -6,4 +6,5 @@
 "message":    "deliverCredentials",
 "client_id":  "<%= @client_id %>",
 "expiry":     "<%= @expiry %>",
-"config":     "<%= @config %>"
+"config":     "<%= @config %>",
+"new_record":     <%= @new_record.to_s %>

--- a/app/views/devise_token_auth/omniauth_success.html.erb
+++ b/app/views/devise_token_auth/omniauth_success.html.erb
@@ -6,5 +6,8 @@
 "message":    "deliverCredentials",
 "client_id":  "<%= @client_id %>",
 "expiry":     "<%= @expiry %>",
-"config":     "<%= @config %>",
-"new_record":     <%= @new_record.to_s %>
+<% if @oauth_registration %>
+"oauth_registration": "true",
+<% end %>
+"config":     "<%= @config %>"
+

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -70,12 +70,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         assert post_message["auth_token"]
         refute post_message["tokens"]
         refute post_message["password"]
-      end
-
-      test 'response contains new_record attr' do
-        post_message = JSON.parse(/postMessage\((?<data>.*), '\*'\);/m.match(response.body)[:data])
-        assert post_message['new_record']
-      end
+      end      
 
       test 'session vars have been cleared' do
         refute request.session['dta.omniauth.auth']
@@ -103,6 +98,56 @@ class OmniauthTest < ActionDispatch::IntegrationTest
           assert @resource.last_sign_in_ip
         end
       end
+
+    end
+
+    describe "oauth_registration attr" do
+
+      def stub_resource
+        relation = {}
+        def relation.first_or_initialize
+          @resource ||= User.new
+          def @resource.save!; end # prevent validation error
+          @resource
+        end        
+        User.stub(:where, relation) do          
+          yield(relation.first_or_initialize)
+        end
+      end
+
+      test 'response contains oauth_registration attr with new user' do
+
+        stub_resource do |resource|
+          def resource.new_record?
+            true
+          end
+          get_via_redirect '/auth/facebook', {
+            auth_origin_url: @redirect_url
+          }
+           
+          post_message = JSON.parse(/postMessage\((?<data>.*), '\*'\);/m.match(response.body)[:data])
+          assert post_message['oauth_registration']
+          assert_match 'oauth_registration', @controller.instance_variable_get(:@auth_origin_url)
+        end
+      end
+
+      test 'response does not contain oauth_registration attr with existing user' do
+
+        stub_resource do |resource|
+          def resource.new_record?
+            false
+          end
+          get_via_redirect '/auth/facebook', {
+            auth_origin_url: @redirect_url
+          }
+          
+          post_message = JSON.parse(/postMessage\((?<data>.*), '\*'\);/m.match(response.body)[:data])
+          refute post_message['oauth_registration']
+          assert_no_match 'oauth_registration', @controller.instance_variable_get(:@auth_origin_url)
+        end
+      end
+
+
 
     end
 

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -72,6 +72,11 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         refute post_message["password"]
       end
 
+      test 'response contains new_record attr' do
+        post_message = JSON.parse(/postMessage\((?<data>.*), '\*'\);/m.match(response.body)[:data])
+        assert post_message['new_record']
+      end
+
       test 'session vars have been cleared' do
         refute request.session['dta.omniauth.auth']
         refute request.session['dta.omniauth.params']


### PR DESCRIPTION
Along with https://github.com/lynndylanhurley/ng-token-auth/pull/156, this allows support for an 'auth:ouath-registration' event when a new user is registered via oauth.