### PR TITLE
Token returning the false issue

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -111,7 +111,7 @@ module DeviseTokenAuth::Concerns::User
       DateTime.strptime(expiry.to_s, '%s') > Time.now and
 
       # ensure that the token is valid
-      BCrypt::Password.new(token_hash) == token
+      BCrypt::Password.new(token_hash).to_s == token
     )
   end
 
@@ -131,7 +131,7 @@ module DeviseTokenAuth::Concerns::User
       Time.parse(updated_at) > Time.now - DeviseTokenAuth.batch_request_buffer_throttle and
 
       # ensure that the token is valid
-      BCrypt::Password.new(last_token) == token
+      BCrypt::Password.new(last_token).to_s == token
     )
   end
 


### PR DESCRIPTION
In app/models/devise_token_auth/concerns/user.rb

In **token_is_current?(token, client_id)**  and **token_can_be_reused?(token, client_id)** method this block of code 
**BCrypt::Password.new(token_hash) == token** is returning false. 
Even though the output of both **BCrypt::Password.new(token_hash) and **token** are same. But when we are comparing the both it returns the **false**

To Fixed that i simply did was placed **BCrypt::Password.new(token_hash).to_s" == **token**
which will **return true** if the token matches.