### PR TITLE
perf(token_is_current?): add simplistic cache to reduce overhead of redundant token checks during validation calls

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -1,6 +1,17 @@
 module DeviseTokenAuth::Concerns::User
   extend ActiveSupport::Concern
 
+  def self.tokens_match?(token_hash, token)
+    @token_equality_cache ||= {}
+
+    key = "#{token_hash}/#{token}"
+    result = @token_equality_cache[key] ||= (BCrypt::Password.new(token_hash) == token)
+    if @token_equality_cache.size > 10000
+      @token_equality_cache = {}
+    end
+    result
+  end
+
   included do
     # Hack to check if devise is already enabled
     unless self.method_defined?(:devise_modules)
@@ -111,7 +122,7 @@ module DeviseTokenAuth::Concerns::User
       DateTime.strptime(expiry.to_s, '%s') > Time.now and
 
       # ensure that the token is valid
-      BCrypt::Password.new(token_hash) == token
+      DeviseTokenAuth::Concerns::User.tokens_match?(token_hash, token)
     )
   end
 


### PR DESCRIPTION
Within `DeviseTokenAuth::Concerns::User#token_is_valid?` we're seeing the `BCrypt::Password.new(token_hash)` + string comparison (casting) operation itself take approximately 75ms on average when validating tokens, which makes it hard / impossible to reach our goal of < 200ms response times for request handling. 

This PR adds a very simplistic caching mechanism that will lookup the check value, saving unnecessary overhead on redundant token / hash checks. It can be iterated on further if a more robust caching implementation is needed / desired. 

This will primarily benefit environments where `change_headers_on_each_request` is disabled, but will still help requests that occur within the `batch_request_buffer_throttle` threshold.

Thanks to @nbrustein for the implementation.