### PR TITLE
Added json support for tokens

### DIFF
--- a/lib/generators/devise_token_auth/install_generator.rb
+++ b/lib/generators/devise_token_auth/install_generator.rb
@@ -115,5 +115,33 @@ module DeviseTokenAuth
       end
       match
     end
+
+    def json_supported_database?
+      (postgres? && postgres_correct_version?) || (mysql? && mysql_correct_version?)
+    end
+
+    def postgres?
+      database_name == 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+    end
+
+    def postgres_correct_version?
+      database_version > '9.3'
+    end
+
+    def mysql?
+      database_name == 'ActiveRecord::ConnectionAdapters::MysqlAdapter'
+    end
+
+    def mysql_correct_version?
+      database_version > '5.7.7'
+    end
+
+    def database_name
+      ActiveRecord::Base.connection.class.name
+    end
+
+    def database_version
+      ActiveRecord::Base.connection.select_value('SELECT VERSION()')
+    end
   end
 end

--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -40,7 +40,7 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       t.string :email
 
       ## Tokens
-      t.text :tokens
+      <%= json_supported_database? ? 't.json :tokens' : 't.text :tokens' %>
 
       t.timestamps
     end


### PR DESCRIPTION
In the installation generator script, the migration template checks to see if the app is using postgres by seeing what sub-class of ``ActiveRecord::ConnectionAdapter`` the app is using. If it is postgres, the app will use a token column instead of a text one.