### PR TITLE
Don't send password reset instructions to unconfirmed email

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -76,12 +76,6 @@ module DeviseTokenAuth::Concerns::User
       # fall back to "default" config name
       opts[:client_config] ||= "default"
 
-      if respond_to?(:pending_reconfirmation?) && pending_reconfirmation?
-        opts[:to] = unconfirmed_email
-      else
-        opts[:to] = email
-      end
-
       send_devise_notification(:reset_password_instructions, token, opts)
 
       token


### PR DESCRIPTION
Background
-------------------------------------------------------------------------------
Currently, we're overriding the Devise's `send_reset_password_instructions` to pass a few additional options.

Problem
-------------------------------------------------------------------------------
As part of this, we're also [overriding the recipient email address](https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/models/devise_token_auth/concerns/user.rb#L79-L83) in order to conditionally send to the user's unconfirmed email. This is a (small) security liability. For more info see issue https://github.com/lynndylanhurley/devise_token_auth/issues/287.

Solution
-------------------------------------------------------------------------------
We still need to override `send_reset_password_instructions`, for good reason. But we don't need to override the `to` address. We can fix the issue by eliminating those specific lines. Tests pass!