### PR TITLE
User Concern (bugfix): Send password reset instructions only to confirmed email address

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -75,13 +75,6 @@ module DeviseTokenAuth::Concerns::User
 
       # fall back to "default" config name
       opts[:client_config] ||= "default"
-
-      if respond_to?(:pending_reconfirmation?) && pending_reconfirmation?
-        opts[:to] = unconfirmed_email
-      else
-        opts[:to] = email
-      end
-
       send_devise_notification(:reset_password_instructions, token, opts)
 
       token


### PR DESCRIPTION
### User Concern (bugfix):  Send password reset instructions only to confirmed email address

This should wrap up the issue described in #287, just removing some code and letting devise route the email under the hood.  I looked for a place to *maybe* add a test around this but I wasn't convinced it's required considering the fallback to devise.  If we find a good place to add one, let me know, i'll add it in.

