### PR TITLE
Fix an issue for not :confirmable users

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -106,7 +106,7 @@ module DeviseTokenAuth
         }
 
         # ensure that user is confirmed
-        @resource.skip_confirmation! unless @resource.confirmed_at
+        @resource.skip_confirmation! if @resource.devise_modules.include?(:confirmable) && !@resource.confirmed_at
 
         @resource.save!
         yield if block_given?
@@ -118,7 +118,9 @@ module DeviseTokenAuth
           config:         params[:config]
         }))
       else
-        raise ActionController::RoutingError.new('Not Found')
+        render json: {
+          success: false
+        }, status: 404
       end
     end
 

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -68,13 +68,13 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
           end
 
           describe 'password reset link failure' do
-            test 'request should not be authorized' do
-              assert_raises(ActionController::RoutingError) {
-                xhr :get, :edit, {
+            test 'respone should return 404' do
+              xhr :get, :edit, {
                   reset_password_token: 'bogus',
                   redirect_url: @mail_redirect_url
-                }
               }
+
+              assert_equal 404, response.status
             end
           end
 
@@ -327,9 +327,38 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
 
         @resource.reload
       end
+    end
+    describe 'unconfirmable user' do
+      setup do
+        @request.env['devise.mapping'] = Devise.mappings[:unconfirmable_user]
+      end
 
-      test 'unconfirmed email user should now be confirmed' do
-        assert @resource.confirmed_at
+      teardown do
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+      end
+
+      before do
+        @resource = unconfirmable_users(:user)
+        @redirect_url = 'http://ng-token-auth.dev'
+
+        xhr :post, :create, {
+          email:        @resource.email,
+          redirect_url: @redirect_url
+        }
+
+        @mail = ActionMailer::Base.deliveries.last
+        @resource.reload
+
+        @mail_config_name  = CGI.unescape(@mail.body.match(/config=([^&]*)&/)[1])
+        @mail_redirect_url = CGI.unescape(@mail.body.match(/redirect_url=([^&]*)&/)[1])
+        @mail_reset_token  = @mail.body.match(/reset_password_token=(.*)\"/)[1]
+
+        xhr :get, :edit, {
+          reset_password_token: @mail_reset_token,
+          redirect_url: @mail_redirect_url
+        }
+
+        @resource.reload
       end
     end
 

--- a/test/dummy/app/models/unconfirmable_user.rb
+++ b/test/dummy/app/models/unconfirmable_user.rb
@@ -1,0 +1,8 @@
+class UnconfirmableUser < ActiveRecord::Base
+  # Include default devise modules.
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable,
+         :trackable, :validatable,
+         :omniauthable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
 
   mount_devise_token_auth_for 'UnregisterableUser', at: 'unregisterable_user_auth', skip: [:registrations]
 
+  mount_devise_token_auth_for 'UnconfirmableUser', at: 'unconfirmable_user_auth'
+
   # test namespacing
   namespace :api do
     scope :v1 do

--- a/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
+++ b/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
@@ -1,0 +1,54 @@
+class DeviseTokenAuthCreateUnconfirmableUsers < ActiveRecord::Migration
+  def change
+    create_table(:unconfirmable_users) do |t|
+      ## Required
+      t.string :provider, :null => false
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, :default => 0, :null => false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :nickname
+      t.string :image
+      t.string :email
+
+      ## Tokens
+      t.text :tokens
+
+      t.timestamps
+    end
+
+    add_index :unconfirmable_users, :email
+    add_index :unconfirmable_users, [:uid, :provider],     :unique => true
+    add_index :unconfirmable_users, :reset_password_token, :unique => true
+    # add_index :nice_users, :confirmation_token,   :unique => true
+    # add_index :nice_users, :unlock_token,         :unique => true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150409095712) do
+ActiveRecord::Schema.define(version: 20150708104536) do
 
   create_table "evil_users", force: :cascade do |t|
     t.string   "email",                  limit: 255
@@ -121,6 +121,31 @@ ActiveRecord::Schema.define(version: 20150409095712) do
 
   add_index "only_email_users", ["email"], name: "index_only_email_users_on_email"
   add_index "only_email_users", ["uid", "provider"], name: "index_only_email_users_on_uid_and_provider", unique: true
+
+  create_table "unconfirmable_users", force: :cascade do |t|
+    t.string   "provider",                            null: false
+    t.string   "uid",                    default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "email"
+    t.text     "tokens"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "unconfirmable_users", ["email"], name: "index_unconfirmable_users_on_email"
+  add_index "unconfirmable_users", ["reset_password_token"], name: "index_unconfirmable_users_on_reset_password_token", unique: true
+  add_index "unconfirmable_users", ["uid", "provider"], name: "index_unconfirmable_users_on_uid_and_provider", unique: true
 
   create_table "unregisterable_users", force: :cascade do |t|
     t.string   "provider",               limit: 255,                null: false

--- a/test/fixtures/unconfirmable_users.yml
+++ b/test/fixtures/unconfirmable_users.yml
@@ -1,0 +1,9 @@
+<% timestamp = DateTime.parse(2.weeks.ago.to_s).to_time.strftime("%F %T") %>
+<% @email = Faker::Internet.email %>
+user:
+  uid:                 "<%= @email %>"
+  email:               "<%= @email %>"
+  provider:            'email'
+  created_at:          '<%= timestamp %>'
+  updated_at:          '<%= timestamp %>'
+  encrypted_password:  <%= User.new.send(:password_digest, 'secret123') %>


### PR DESCRIPTION
When we edit user password (after asking reset). Do not run skip_confirmation! is the user is not :confirmable

Also return json and 404 when user is not found