### PR TITLE
Set default provider to "email" in migration

### DIFF
--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -2,7 +2,7 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
   def change
     create_table(:<%= user_class.pluralize.underscore %>) do |t|
       ## Required
-      t.string :provider, :null => false
+      t.string :provider, :null => false, :default => "email"
       t.string :uid, :null => false, :default => ""
 
       ## Database authenticatable


### PR DESCRIPTION
This change should fix incompatibility with standard devise controllers using default
migrations. Standard devise allows for provider to be null, but devise_token_auth requires it to have a value (as enforced by the default migration). The generated migration now sets this field to "email" by default. It should resolve #257 when the new migration is used. Setting the provider in the standard registrations controller is now redundant, but I left it as is to avoid breaking existing installations using the old migration.