### PR TITLE
Disabled serialization for JSON type columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
 before_script:
   - mysql -e 'create database devise_token_auth_test'
   - psql -c 'create database devise_token_auth_test' -U postgres
+
+addons:
+  postgresql: "9.3"

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -21,7 +21,9 @@ module DeviseTokenAuth::Concerns::User
       self.devise_modules.delete(:omniauthable)
     end
 
-    serialize :tokens, JSON
+    unless tokens_has_json_column_type?
+      serialize :tokens, JSON
+    end
 
     validates :email, presence: true, email: true, if: Proc.new { |u| u.provider == 'email' }
     validates_presence_of :uid, if: Proc.new { |u| u.provider != 'email' }
@@ -79,6 +81,15 @@ module DeviseTokenAuth::Concerns::User
       send_devise_notification(:reset_password_instructions, token, opts)
 
       token
+    end
+  end
+
+  module ClassMethods
+    protected
+    
+
+    def tokens_has_json_column_type?
+      table_exists? && self.columns_hash['tokens'] && self.columns_hash['tokens'].type.in?([:json, :jsonb])
     end
   end
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -251,10 +251,12 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def destroy_expired_tokens
-    self.tokens.delete_if{|cid,v|
-      expiry = v[:expiry] || v["expiry"]
-      DateTime.strptime(expiry.to_s, '%s') < Time.now
-    }
+    if self.tokens
+      self.tokens.delete_if do |cid, v|
+        expiry = v[:expiry] || v["expiry"]
+        DateTime.strptime(expiry.to_s, '%s') < Time.now
+      end
+    end
   end
 
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -19,5 +19,6 @@ module Dummy
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/test/dummy/db/migrate/20140715061447_devise_token_auth_create_users.rb
+++ b/test/dummy/db/migrate/20140715061447_devise_token_auth_create_users.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateUsers < ActiveRecord::Migration
   def change
     create_table(:users) do |t|
@@ -42,7 +44,11 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration
       t.string :uid, :null => false, :default => ""
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end

--- a/test/dummy/db/migrate/20140715061805_devise_token_auth_create_mangs.rb
+++ b/test/dummy/db/migrate/20140715061805_devise_token_auth_create_mangs.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateMangs < ActiveRecord::Migration
   def change
     create_table(:mangs) do |t|
@@ -42,7 +44,11 @@ class DeviseTokenAuthCreateMangs < ActiveRecord::Migration
       t.string :uid, :null => false, :default => ""
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end

--- a/test/dummy/db/migrate/20140928231203_devise_token_auth_create_evil_users.rb
+++ b/test/dummy/db/migrate/20140928231203_devise_token_auth_create_evil_users.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateEvilUsers < ActiveRecord::Migration
   def change
     create_table(:evil_users) do |t|
@@ -40,7 +42,11 @@ class DeviseTokenAuthCreateEvilUsers < ActiveRecord::Migration
       t.string :uid, :null => false, :default => ""
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       ## etc.
       t.string :favorite_color

--- a/test/dummy/db/migrate/20141222035835_devise_token_auth_create_only_email_users.rb
+++ b/test/dummy/db/migrate/20141222035835_devise_token_auth_create_only_email_users.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateOnlyEmailUsers < ActiveRecord::Migration
   def change
     create_table(:only_email_users) do |t|
@@ -40,7 +42,11 @@ class DeviseTokenAuthCreateOnlyEmailUsers < ActiveRecord::Migration
       t.string :email
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end

--- a/test/dummy/db/migrate/20141222053502_devise_token_auth_create_unregisterable_users.rb
+++ b/test/dummy/db/migrate/20141222053502_devise_token_auth_create_unregisterable_users.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateUnregisterableUsers < ActiveRecord::Migration
   def change
     create_table(:unregisterable_users) do |t|
@@ -40,7 +42,11 @@ class DeviseTokenAuthCreateUnregisterableUsers < ActiveRecord::Migration
       t.string :email
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end

--- a/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
+++ b/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateNiceUsers < ActiveRecord::Migration
   def change
     create_table(:nice_users) do |t|
@@ -40,7 +42,11 @@ class DeviseTokenAuthCreateNiceUsers < ActiveRecord::Migration
       t.string :email
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end

--- a/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
+++ b/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
@@ -1,3 +1,5 @@
+include MigrationDatabaseHelper
+
 class DeviseTokenAuthCreateUnconfirmableUsers < ActiveRecord::Migration
   def change
     create_table(:unconfirmable_users) do |t|
@@ -40,7 +42,11 @@ class DeviseTokenAuthCreateUnconfirmableUsers < ActiveRecord::Migration
       t.string :email
 
       ## Tokens
-      t.text :tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end

--- a/test/dummy/lib/migration_database_helper.rb
+++ b/test/dummy/lib/migration_database_helper.rb
@@ -1,0 +1,29 @@
+module MigrationDatabaseHelper
+  def json_supported_database?
+    (postgres? && postgres_correct_version?) || (mysql? && mysql_correct_version?)
+  end
+
+  def postgres?
+    database_name == 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
+  end
+
+  def postgres_correct_version?
+    database_version > '9.3'
+  end
+
+  def mysql?
+    database_name == 'ActiveRecord::ConnectionAdapters::MysqlAdapter'
+  end
+
+  def mysql_correct_version?
+    database_version > '5.7.7'
+  end
+
+  def database_name
+    ActiveRecord::Base.connection.class.name
+  end
+
+  def database_version
+    ActiveRecord::Base.connection.select_value('SELECT VERSION()')
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -87,6 +87,19 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'nil tokens are handled properly' do
+      before do
+        @resource = users(:confirmed_email_user)
+        @resource.skip_confirmation!
+        @resource.save!
+      end
+
+      test 'tokens can be set to nil' do
+        @resource.tokens = nil
+        assert @resource.save
+      end
+    end
+
     describe "#generate_url" do
       test 'URI fragment should appear at the end of URL' do
         params = {client_id: 123}


### PR DESCRIPTION
The default migration uses the JSON type for databases (such as Postgres) that support it. The concern no longer attempts to invalidly serialize the tokens field if it is backed by a JSON column. This fixes the TypeError encountered when the JSON field is nil (as it is by default). The tests have also been updated to test the JSON column type if it is available. I have also bumped the postgresql version on Travis CI to 9.3 so JSON datatypes would be available to test.

This also resolves #271 by explicitly checking if the tokens field is nil before attempting to delete expired tokens.