### PR TITLE
Removing the unique emails validation

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -28,9 +28,6 @@ module DeviseTokenAuth::Concerns::User
     validates :email, presence: true, email: true, if: Proc.new { |u| u.provider == 'email' }
     validates_presence_of :uid, if: Proc.new { |u| u.provider != 'email' }
 
-    # only validate unique emails among email registration users
-    validate :unique_email_user, on: :create
-
     # can't set default on text fields in mysql, simulate here instead.
     after_save :set_empty_token_hash
     after_initialize :set_empty_token_hash


### PR DESCRIPTION
__Removed the unique emails validation. It was conflicting with Devise's scoping login to subdomain.__

Explaining:
As seen in [Devise's wiki](https://github.com/plataformatec/devise/wiki/How-to:-Scope-login-to-subdomain), it is possible to scope the login to subdomains, allowing the creation of the resource with same email as many times as needed - as long as the subdomain changes. On the other hand, devise_token_auth had a unique email validation that kept this feature from working.
This validation was removed and anyone that wants to have unique emails must use Devise's **validatable** module.