### PR TITLE
Tests to ensure standard devise has greater priority than tokens

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -69,7 +69,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     # Generate new client_id with existing authentication
     @client_id = nil unless @used_auth_by_token
 
-    if not DeviseTokenAuth.change_headers_on_each_request
+    if @used_auth_by_token and not DeviseTokenAuth.change_headers_on_each_request
       auth_header = @resource.build_auth_header(@token, @client_id)
 
       # update the response header

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,6 +10,17 @@ confirmed_email_user:
   updated_at:         '<%= timestamp %>'
   encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
 
+<% @second_email = Faker::Internet.email %>
+second_confirmed_email_user:
+  uid:                "<%= @second_email %>"
+  email:              "<%= @second_email %>"
+  nickname:           'stimpy2'
+  provider:           'email'
+  confirmed_at:       '<%= timestamp %>'
+  created_at:         '<%= timestamp %>'
+  updated_at:         '<%= timestamp %>'
+  encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
+
 <% @fb_email = Faker::Internet.email %>
 duplicate_email_facebook_user:
   uid:                "<%= Faker::Number.number(10) %>"


### PR DESCRIPTION
This PR adds some tests to make sure devise_token_auth doesn't conflict with devise in some edge cases (namely when token information is provided alongside a standard devise session).