### PR TITLE
#340 Restrict access to controllers methods

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -2,6 +2,7 @@ module DeviseTokenAuth
   class ApplicationController < DeviseController
     include DeviseTokenAuth::Concerns::SetUserByToken
 
+    protected
 
     def resource_class(m=nil)
       if m

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -7,6 +7,8 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     after_action :update_auth_header
   end
 
+  protected
+
   # keep track of request duration
   def set_request_start
     @request_started_at = Time.now

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -47,6 +47,8 @@ module DeviseTokenAuth
       render_data_or_redirect('authFailure', {error: @error})
     end
 
+    protected
+
     # this will be determined differently depending on the action that calls
     # it. redirect_callbacks is called upon returning from successful omniauth
     # authentication, and the target params live in an omniauth-specific
@@ -71,8 +73,6 @@ module DeviseTokenAuth
       @_omniauth_params
       
     end
-
-    protected
 
     # break out provider attribute assignment for easy method extension
     def assign_provider_attrs(user, auth_hash)

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -22,26 +22,130 @@ module DeviseTokenAuth
       redirect_to redirect_route
     end
 
-    def get_resource_from_auth_hash
-      # find or create user by provider and provider uid
-      @resource = resource_class.where({
-        uid:      auth_hash['uid'],
-        provider: auth_hash['provider']
-      }).first_or_initialize
+    def omniauth_success
+      get_resource_from_auth_hash
+      create_token_info
+      set_token_on_resource
+      create_auth_params
 
-      if @resource.new_record?
-        @oauth_registration = true
-        set_random_password
+      if resource_class.devise_modules.include?(:confirmable)
+        # don't send confirmation email!!!
+        @resource.skip_confirmation!
       end
 
-      # sync user info with provider, update/generate auth token
-      assign_provider_attrs(@resource, auth_hash)
+      sign_in(:user, @resource, store: false, bypass: false)
 
-      # assign any additional (whitelisted) attributes
-      extra_params = whitelisted_params
-      @resource.assign_attributes(extra_params) if extra_params
+      @resource.save!
 
-      @resource
+      yield if block_given?
+
+      render_data_or_redirect('deliverCredentials', @resource.as_json.merge(@auth_params.as_json))
+    end
+
+    def omniauth_failure
+      @error = params[:message]
+      render_data_or_redirect('authFailure', {error: @error})
+    end
+
+    # this will be determined differently depending on the action that calls
+    # it. redirect_callbacks is called upon returning from successful omniauth
+    # authentication, and the target params live in an omniauth-specific
+    # request.env variable. this variable is then persisted thru the redirect
+    # using our own dta.omniauth.params session var. the omniauth_success
+    # method will access that session var and then destroy it immediately
+    # after use.  In the failure case, finally, the omniauth params
+    # are added as query params in our monkey patch to OmniAuth in engine.rb
+    def omniauth_params
+      if !defined?(@_omniauth_params)
+        if request.env['omniauth.params'] && request.env['omniauth.params'].any?
+          @_omniauth_params = request.env['omniauth.params']
+        elsif session['dta.omniauth.params'] && session['dta.omniauth.params'].any?
+          @_omniauth_params ||= session.delete('dta.omniauth.params')
+          @_omniauth_params
+        elsif params['omniauth_window_type']
+          @_omniauth_params = params.slice('omniauth_window_type', 'auth_origin_url', 'resource_class', 'origin')
+        else
+          @_omniauth_params = {}
+        end
+      end
+      @_omniauth_params
+      
+    end
+
+    protected
+
+    # break out provider attribute assignment for easy method extension
+    def assign_provider_attrs(user, auth_hash)
+      user.assign_attributes({
+        nickname: auth_hash['info']['nickname'],
+        name:     auth_hash['info']['name'],
+        image:    auth_hash['info']['image'],
+        email:    auth_hash['info']['email']
+      })
+    end
+
+    # derive allowed params from the standard devise parameter sanitizer
+    def whitelisted_params
+      whitelist = devise_parameter_sanitizer.for(:sign_up)
+
+      whitelist.inject({}){|coll, key|
+        param = omniauth_params[key.to_s]
+        if param
+          coll[key] = param
+        end
+        coll
+      }
+    end
+
+    def resource_class(mapping = nil)
+      if omniauth_params['resource_class']
+        omniauth_params['resource_class'].constantize
+      elsif params['resource_class']
+        params['resource_class'].constantize
+      else
+        raise "No resource_class found"
+      end
+    end
+
+    def resource_name
+      resource_class
+    end
+
+    def omniauth_window_type
+      omniauth_params['omniauth_window_type']
+    end
+
+    def auth_origin_url
+      omniauth_params['auth_origin_url'] || omniauth_params['origin']
+    end
+
+    # in the success case, omniauth_window_type is in the omniauth_params.
+    # in the failure case, it is in a query param.  See monkey patch above
+    def omniauth_window_type
+      omniauth_params.nil? ? params['omniauth_window_type'] : omniauth_params['omniauth_window_type']
+    end
+
+    # this sesison value is set by the redirect_callbacks method. its purpose
+    # is to persist the omniauth auth hash value thru a redirect. the value
+    # must be destroyed immediatly after it is accessed by omniauth_success
+    def auth_hash
+      @_auth_hash ||= session.delete('dta.omniauth.auth')
+      @_auth_hash
+    end
+
+    # ensure that this controller responds to :devise_controller? conditionals.
+    # this is used primarily for access to the parameter sanitizers.
+    def assert_is_devise_resource!
+      true
+    end
+
+    # necessary for access to devise_parameter_sanitizers
+    def devise_mapping
+      if omniauth_params
+        Devise.mappings[omniauth_params['resource_class'].underscore.to_sym]
+      else
+        request.env['devise.mapping']
+      end
     end
 
     def set_random_password
@@ -124,131 +228,26 @@ module DeviseTokenAuth
             </html>| 
     end
 
-    def omniauth_success
-      get_resource_from_auth_hash
-      create_token_info
-      set_token_on_resource
-      create_auth_params
+    def get_resource_from_auth_hash
+      # find or create user by provider and provider uid
+      @resource = resource_class.where({
+        uid:      auth_hash['uid'],
+        provider: auth_hash['provider']
+      }).first_or_initialize
 
-      if resource_class.devise_modules.include?(:confirmable)
-        # don't send confirmation email!!!
-        @resource.skip_confirmation!
+      if @resource.new_record?
+        @oauth_registration = true
+        set_random_password
       end
 
-      sign_in(:user, @resource, store: false, bypass: false)
+      # sync user info with provider, update/generate auth token
+      assign_provider_attrs(@resource, auth_hash)
 
-      @resource.save!
+      # assign any additional (whitelisted) attributes
+      extra_params = whitelisted_params
+      @resource.assign_attributes(extra_params) if extra_params
 
-      yield if block_given?
-
-      render_data_or_redirect('deliverCredentials', @resource.as_json.merge(@auth_params.as_json))
-    end
-
-
-    # break out provider attribute assignment for easy method extension
-    def assign_provider_attrs(user, auth_hash)
-      user.assign_attributes({
-        nickname: auth_hash['info']['nickname'],
-        name:     auth_hash['info']['name'],
-        image:    auth_hash['info']['image'],
-        email:    auth_hash['info']['email']
-      })
-    end
-
-
-    def omniauth_failure
-      @error = params[:message]
-      render_data_or_redirect('authFailure', {error: @error})
-    end
-
-
-    # derive allowed params from the standard devise parameter sanitizer
-    def whitelisted_params
-      whitelist = devise_parameter_sanitizer.for(:sign_up)
-
-      whitelist.inject({}){|coll, key|
-        param = omniauth_params[key.to_s]
-        if param
-          coll[key] = param
-        end
-        coll
-      }
-    end
-
-    def resource_class(mapping = nil)
-      if omniauth_params['resource_class']
-        omniauth_params['resource_class'].constantize
-      elsif params['resource_class']
-        params['resource_class'].constantize
-      else
-        raise "No resource_class found"
-      end
-    end
-
-    def resource_name
-      resource_class
-    end
-
-    # this will be determined differently depending on the action that calls
-    # it. redirect_callbacks is called upon returning from successful omniauth
-    # authentication, and the target params live in an omniauth-specific
-    # request.env variable. this variable is then persisted thru the redirect
-    # using our own dta.omniauth.params session var. the omniauth_success
-    # method will access that session var and then destroy it immediately
-    # after use.  In the failure case, finally, the omniauth params
-    # are added as query params in our monkey patch to OmniAuth in engine.rb
-    def omniauth_params
-      if !defined?(@_omniauth_params)
-        if request.env['omniauth.params'] && request.env['omniauth.params'].any?
-          @_omniauth_params = request.env['omniauth.params']
-        elsif session['dta.omniauth.params'] && session['dta.omniauth.params'].any?
-          @_omniauth_params ||= session.delete('dta.omniauth.params')
-          @_omniauth_params
-        elsif params['omniauth_window_type']
-          @_omniauth_params = params.slice('omniauth_window_type', 'auth_origin_url', 'resource_class', 'origin')
-        else
-          @_omniauth_params = {}
-        end
-      end
-      @_omniauth_params
-      
-    end
-
-    def omniauth_window_type
-      omniauth_params['omniauth_window_type']
-    end
-
-    def auth_origin_url
-      omniauth_params['auth_origin_url'] || omniauth_params['origin']
-    end
-
-    # in the success case, omniauth_window_type is in the omniauth_params.
-    # in the failure case, it is in a query param.  See monkey patch above
-    def omniauth_window_type
-      omniauth_params.nil? ? params['omniauth_window_type'] : omniauth_params['omniauth_window_type']
-    end
-
-    # this sesison value is set by the redirect_callbacks method. its purpose
-    # is to persist the omniauth auth hash value thru a redirect. the value
-    # must be destroyed immediatly after it is accessed by omniauth_success
-    def auth_hash
-      @_auth_hash ||= session.delete('dta.omniauth.auth')
-      @_auth_hash
-    end
-
-    # ensure that this controller responds to :devise_controller? conditionals.
-    # this is used primarily for access to the parameter sanitizers.
-    def assert_is_devise_resource!
-      true
-    end
-
-    # necessary for access to devise_parameter_sanitizers
-    def devise_mapping
-      if omniauth_params
-        Devise.mappings[omniauth_params['resource_class'].underscore.to_sym]
-      else
-        request.env['devise.mapping']
-      end
+      @resource
     end
 
   end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -165,6 +165,8 @@ module DeviseTokenAuth
       end
     end
 
+    protected
+
     def resource_update_method
       if DeviseTokenAuth.check_current_password_before_update != false
         "update_with_password"
@@ -173,12 +175,14 @@ module DeviseTokenAuth
       end
     end
 
-    def password_resource_params
-      params.permit(devise_parameter_sanitizer.for(:account_update))
-    end
+    private
 
     def resource_params
       params.permit(:email, :password, :password_confirmation, :current_password, :reset_password_token)
+    end
+
+    def password_resource_params
+      params.permit(devise_parameter_sanitizer.for(:account_update))
     end
 
   end

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -86,12 +86,10 @@ module DeviseTokenAuth
       end
     end
 
+    protected
+
     def valid_params?(key, val)
       resource_params[:password] && key && val
-    end
-
-    def resource_params
-      params.permit(devise_parameter_sanitizer.for(:sign_in))
     end
 
     def get_auth_params
@@ -117,5 +115,12 @@ module DeviseTokenAuth
         val: auth_val
       }
     end
+
+    private
+
+    def resource_params
+      params.permit(devise_parameter_sanitizer.for(:sign_in))
+    end
+
   end
 end

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -31,7 +31,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
 
     test 'request should pass correct redirect_url' do
       get_success
-      assert_equal @redirect_url, controller.omniauth_params['auth_origin_url']
+      assert_equal @redirect_url, controller.send(:omniauth_params)['auth_origin_url']
     end
 
     test 'user should have been created' do
@@ -72,7 +72,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         get_success
       end
       test 'request should determine the correct resource_class' do
-        assert_equal 'User', controller.omniauth_params['resource_class']
+        assert_equal 'User', controller.send(:omniauth_params)['resource_class']
       end
 
       test 'user should be of the correct class' do
@@ -90,7 +90,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         @resource = assigns(:resource)
       end
       test 'request should determine the correct resource_class' do
-        assert_equal 'Mang', controller.omniauth_params['resource_class']
+        assert_equal 'Mang', controller.send(:omniauth_params)['resource_class']
       end
         test 'user should be of the correct class' do
         assert_equal Mang, @resource.class


### PR DESCRIPTION
DeviseTokenAuth::OmniauthCallbacksController#omniauth_params is still need to be restricted but we need to create appropriate tests for this. 