### PR TITLE
Fully support OmniauthCallbacksController action overrides. Fixes #186.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,0 @@
-Rails.application.routes.draw do
-  if defined?(::OmniAuth)
-    get "#{DeviseTokenAuth.omniauth_prefix}/:provider/callback", to: "devise_token_auth/omniauth_callbacks#redirect_callbacks"
-    get "#{DeviseTokenAuth.omniauth_prefix}/failure", to: "devise_token_auth/omniauth_callbacks#omniauth_failure"
-  end
-end

--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -52,6 +52,9 @@ module ActionDispatch::Routing
             match "#{full_path}/failure",             controller: omniauth_ctrl, action: "omniauth_failure", via: [:get]
             match "#{full_path}/:provider/callback",  controller: omniauth_ctrl, action: "omniauth_success", via: [:get]
 
+            match "#{DeviseTokenAuth.omniauth_prefix}/:provider/callback", controller: omniauth_ctrl, action: "redirect_callbacks", via: [:get]
+            match "#{DeviseTokenAuth.omniauth_prefix}/failure", controller: omniauth_ctrl, action: "omniauth_failure", via: [:get]
+
             # preserve the resource class thru oauth authentication by setting name of
             # resource as "resource_class" param
             match "#{full_path}/:provider", to: redirect{|params, request|


### PR DESCRIPTION
Remove `config/routes.rb` and define all routes in `lib/devise_token_auth/rails/routes.rb`; this ensures that all `OmniauthCallbacksController` actions can be overridden.