### PR TITLE
Fix concern not being inserted for rails-api apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The following events will take place when using the install generator:
 
 * Routes will be appended to file at `config/routes.rb`. [Read more](#mounting-routes).
 
-* A concern will be included by your application controller at `app/controllers/application_controller.rb`. *If you are using `rails-api` instead of vanilla rails, you will need to add this concern manually.* [Read more](#controller-methods).
+* A concern will be included by your application controller at `app/controllers/application_controller.rb`. [Read more](#controller-methods).
 
 * A migration file will be created in the `db/migrate` directory. Inspect the migrations file, add additional columns if necessary, and then run the migration:
 

--- a/lib/generators/devise_token_auth/install_generator.rb
+++ b/lib/generators/devise_token_auth/install_generator.rb
@@ -48,6 +48,11 @@ module DeviseTokenAuth
       if File.exist?(File.join(destination_root, fname))
         if parse_file_for_line(fname, line)
           say_status("skipped", "Concern is already included in the application controller.")
+        elsif is_rails_api?
+          inject_into_file fname, after: "class ApplicationController < ActionController::API\n" do <<-'RUBY'
+  include DeviseTokenAuth::Concerns::SetUserByToken
+          RUBY
+          end
         else
           inject_into_file fname, after: "class ApplicationController < ActionController::Base\n" do <<-'RUBY'
   include DeviseTokenAuth::Concerns::SetUserByToken
@@ -114,6 +119,12 @@ module DeviseTokenAuth
         end
       end
       match
+    end
+
+    def is_rails_api?
+      fname = "app/controllers/application_controller.rb"
+      line = "class ApplicationController < ActionController::API"
+      parse_file_for_line(fname, line)
     end
 
     def json_supported_database?


### PR DESCRIPTION
Rails-api apps have an ApplicationController just like vanilla rails apps, except in rails-api, it inherits from ActionController::API, instead of the usual ActionController::Base.