### PR TITLE
Allowing devise patch version updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ PATH
   remote: .
   specs:
     devise_token_auth (0.1.34)
-      devise (= 3.5.1)
+      devise (~> 3.5.1)
       rails (~> 4.2)
 
 GEM
@@ -76,7 +76,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     ansi (1.5.0)
-    arel (6.0.2)
+    arel (6.0.3)
     attr_encrypted (1.3.4)
       encryptor (>= 1.3.0)
     bcrypt (3.1.10)
@@ -84,7 +84,7 @@ GEM
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
-    devise (3.5.1)
+    devise (3.5.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -101,7 +101,7 @@ GEM
     ffi (1.9.10)
     formatador (0.2.5)
     fuzz_ball (0.9.1)
-    globalid (0.3.5)
+    globalid (0.3.6)
       activesupport (>= 4.1.0)
     guard (2.13.0)
       formatador (>= 0.2.4)
@@ -123,7 +123,7 @@ GEM
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    loofah (2.0.2)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
     mail (2.6.3)
@@ -132,7 +132,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
-    minitest (5.7.0)
+    minitest (5.8.0)
     minitest-focus (1.1.2)
       minitest (>= 4, < 6)
     minitest-rails (2.2.0)
@@ -193,7 +193,7 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.6)
+    rails-dom-testing (1.0.7)
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
@@ -218,7 +218,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    sprockets (3.2.0)
+    sprockets (3.3.2)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
       actionpack (>= 3.0)
@@ -259,3 +259,6 @@ DEPENDENCIES
   rack-cors
   sqlite3 (~> 1.3)
   thor
+
+BUNDLED WITH
+   1.10.6

--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 4.2"
-  s.add_dependency "devise", "3.5.1"
+  s.add_dependency "devise", "~> 3.5.1"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency 'pg'


### PR DESCRIPTION
I have just changed the line specifying the exact version 3.5.1 of devise to be `"~> 3.5.1"` to allow for devise patch version updates. This fixes #351.