### PR TITLE
Correct handling namespaced resources

### DIFF
--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -22,7 +22,7 @@ module ActionDispatch::Routing
       # remove any unwanted devise modules
       opts[:skip].each{|item| controllers.delete(item)}
 
-      devise_for resource.pluralize.underscore.to_sym,
+      devise_for resource.pluralize.underscore.gsub('/', '_').to_sym,
         :class_name  => resource,
         :module      => :devise,
         :path        => "#{opts[:at]}",
@@ -43,7 +43,7 @@ module ActionDispatch::Routing
           parent:       nil
         )
 
-        devise_scope resource.underscore.to_sym do
+        devise_scope resource.underscore.gsub('/', '_').to_sym do
           # path to verify token validity
           get "#{full_path}/validate_token", controller: "#{token_validations_ctrl}", action: "validate_token"
 


### PR DESCRIPTION
Fixes issue [#348](https://github.com/lynndylanhurley/devise_token_auth/issues/348).
Recipe to reproduce bug:
Add route:
```ruby
    mount_devise_token_auth_for 'Project::ACL::User', at: 'api/auth'
```

Sign in and then try to validate token.
You will get:
```
Processing by DeviseTokenAuth::TokenValidationsController#validate_token as */*
Completed 500 Internal Server Error in 3ms (ActiveRecord: 0.0ms)

NoMethodError (undefined method `name' for nil:NilClass):
  devise (3.5.1) app/controllers/devise_controller.rb:38:in `resource_name'
  devise_token_auth (0.1.34) app/controllers/devise_token_auth/application_controller.rb:10:in `resource_class'
  devise_token_auth (0.1.34) app/controllers/devise_token_auth/concerns/set_user_by_token.rb:19:in `set_user_by_token'
```