### PR TITLE
Add description to readme about the devise.rb initializer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ The following settings are available for configuration in `config/initializers/d
 | **`default_password_reset_url`** | `nil` | By default this value is expected to be sent by the client so that the API knows where to redirect users after successful password resets. If this param is set, the API will redirect to this value when no value is provided by the cilent. |
 | **`redirect_whitelist`** | `nil` | As an added security measure, you can limit the URLs to which the API will redirect after email token validation (password reset, email confirmation, etc.). This value should be an array containing exact matches to the client URLs to be visited after validation. |
 
+Additionally, you can configure other aspects of devise by manually creating the traditional devise.rb file at `config/initializers/devise.rb`. Here are some examples of what you can do in this file:
+
+~~~ruby
+Devise.setup do |config|
+  # The e-mail address that mail will appear to be sent from
+  # If absent, mail is sent from "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "support@myapp.com"
+
+  # If using rails-api, you may want to tell devise to not use ActionDispatch::Flash
+  # middleware b/c rails-api does not include it.
+  # See: http://stackoverflow.com/q/19600905/806956
+  config.navigational_formats = [:json]
+end
+~~~
 
 ## OmniAuth authentication
 


### PR DESCRIPTION
Right now the readme doesn't contain any info about this file, although it is an important part of configuring this library, and the [example app uses it](https://github.com/lynndylanhurley/devise_token_auth_demo/blob/master/config/initializers/devise.rb). Adding this section here should make it a little easier on newcomers to learn about this part of configuring devise.