### PR TITLE
Allow authentication with an API Token 

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -13,6 +13,7 @@ module DeviseTokenAuth
     def create
       # Check
       field = (resource_params.keys.map(&:to_sym) & resource_class.authentication_keys).first
+      api_token = request_authentication_header_value
 
       @resource = nil
       if field
@@ -27,11 +28,12 @@ module DeviseTokenAuth
         if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
           q = "BINARY " + q
         end
-
         @resource = resource_class.where(q, q_value).first
+      elsif api_token
+        @resource = resource_class.where(api_token: api_token).first
       end
 
-      if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
+      if api_token_or_username_password_valid?(api_token, field, q_value) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
         # create client id
         @client_id = SecureRandom.urlsafe_base64(nil, false)
         @token     = SecureRandom.urlsafe_base64(nil, false)
@@ -120,6 +122,14 @@ module DeviseTokenAuth
 
     def resource_params
       params.permit(devise_parameter_sanitizer.for(:sign_in))
+    end
+
+    def request_authentication_header_value
+      request.headers[DeviseTokenAuth.default_authentication_header]
+    end
+
+    def api_token_or_username_password_valid?(api_token, field, q_value)
+      ((@resource and api_token) or (@resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password])))
     end
 
   end

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -53,6 +53,16 @@ module DeviseTokenAuth::Concerns::User
       false
     end
 
+    def password_required?
+      return super unless self.provider == "api"
+      false
+    end
+
+    def password_changed?
+      return super unless self.provider == "api"
+      false
+    end
+
     # override devise method to include additional info as opts hash
     def send_confirmation_instructions(opts=nil)
       unless @raw_confirmation_token
@@ -88,7 +98,7 @@ module DeviseTokenAuth::Concerns::User
 
   module ClassMethods
     protected
-    
+
 
     def tokens_has_json_column_type?
       table_exists? && self.columns_hash['tokens'] && self.columns_hash['tokens'].type.in?([:json, :jsonb])

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -16,7 +16,8 @@ module DeviseTokenAuth
                  :default_confirm_success_url,
                  :default_password_reset_url,
                  :redirect_whitelist,
-                 :check_current_password_before_update
+                 :check_current_password_before_update,
+                 :default_authentication_header
 
   self.change_headers_on_each_request       = true
   self.token_lifespan                       = 2.weeks
@@ -26,6 +27,7 @@ module DeviseTokenAuth
   self.default_password_reset_url           = nil
   self.redirect_whitelist                   = nil
   self.check_current_password_before_update = false
+  self.default_authentication_header         = 'Authorization'
 
   def self.setup(&block)
     yield self

--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -42,6 +42,9 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       ## Tokens
       <%= json_supported_database? ? 't.json :tokens' : 't.text :tokens' %>
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       t.timestamps
     end
 

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -9,217 +9,284 @@ require 'test_helper'
 class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
   describe DeviseTokenAuth::SessionsController do
     describe "Confirmed user" do
-      before do
-        @existing_user = users(:confirmed_email_user)
-        @existing_user.skip_confirmation!
-        @existing_user.save!
-      end
-
-      describe 'success' do
+      describe "with api token" do
         before do
-          @old_sign_in_count      = @existing_user.sign_in_count
-          @old_current_sign_in_at = @existing_user.current_sign_in_at
-          @old_last_sign_in_at    = @existing_user.last_sign_in_at
-          @old_sign_in_ip         = @existing_user.current_sign_in_ip
-          @old_last_sign_in_ip    = @existing_user.last_sign_in_ip
-
-          xhr :post, :create, {
-            email: @existing_user.email,
-            password: 'secret123'
-          }
-
-          @resource = assigns(:resource)
-          @data = JSON.parse(response.body)
-
-          @new_sign_in_count      = @resource.sign_in_count
-          @new_current_sign_in_at = @resource.current_sign_in_at
-          @new_last_sign_in_at    = @resource.last_sign_in_at
-          @new_sign_in_ip         = @resource.current_sign_in_ip
-          @new_last_sign_in_ip    = @resource.last_sign_in_ip
+          @existing_user = users(:confirmed_api_user)
+          @existing_user.skip_confirmation!
+          @existing_user.save!
         end
 
-        test "request should succeed" do
-          assert_equal 200, response.status
-        end
+        describe 'success' do
+          before do
+            @old_sign_in_count      = @existing_user.sign_in_count
+            @old_current_sign_in_at = @existing_user.current_sign_in_at
+            @old_last_sign_in_at    = @existing_user.last_sign_in_at
+            @old_sign_in_ip         = @existing_user.current_sign_in_ip
+            @old_last_sign_in_ip    = @existing_user.last_sign_in_ip
 
-        test "request should return user data" do
-          assert_equal @existing_user.email, @data['data']['email']
-        end
+            @request.headers[DeviseTokenAuth.default_authentication_header] = @existing_user.api_token
 
-        describe 'trackable' do
-          test 'sign_in_count incrementns' do
-            assert_equal @old_sign_in_count + 1, @new_sign_in_count
+            xhr :post, :create
+
+            @resource = assigns(:resource)
+            @data = JSON.parse(response.body)
+
+            @new_sign_in_count      = @resource.sign_in_count
+            @new_current_sign_in_at = @resource.current_sign_in_at
+            @new_last_sign_in_at    = @resource.last_sign_in_at
+            @new_sign_in_ip         = @resource.current_sign_in_ip
+            @new_last_sign_in_ip    = @resource.last_sign_in_ip
           end
 
-          test 'current_sign_in_at is updated' do
-            refute @old_current_sign_in_at
-            assert @new_current_sign_in_at
+          test "request should succeed" do
+            assert_equal 200, response.status
           end
 
-          test 'last_sign_in_at is updated' do
-            refute @old_last_sign_in_at
-            assert @new_last_sign_in_at
+          test "request should return user data" do
+            assert_equal @existing_user.email, @data['data']['email']
           end
 
-          test 'sign_in_ip is updated' do
-            refute @old_sign_in_ip
-            assert_equal "0.0.0.0", @new_sign_in_ip
+          describe 'trackable' do
+            test 'sign_in_count incrementns' do
+              assert_equal @old_sign_in_count + 1, @new_sign_in_count
+            end
+
+            test 'current_sign_in_at is updated' do
+              refute @old_current_sign_in_at
+              assert @new_current_sign_in_at
+            end
+
+            test 'last_sign_in_at is updated' do
+              refute @old_last_sign_in_at
+              assert @new_last_sign_in_at
+            end
+
+            test 'sign_in_ip is updated' do
+              refute @old_sign_in_ip
+              assert_equal "0.0.0.0", @new_sign_in_ip
+            end
+
+            test 'last_sign_in_ip is updated' do
+              refute @old_last_sign_in_ip
+              assert_equal "0.0.0.0", @new_last_sign_in_ip
+            end
+          end
+        end
+      end
+
+      describe "with user/pass" do
+        before do
+          @existing_user = users(:confirmed_email_user)
+          @existing_user.skip_confirmation!
+          @existing_user.save!
+        end
+
+        describe 'success' do
+          before do
+            @old_sign_in_count      = @existing_user.sign_in_count
+            @old_current_sign_in_at = @existing_user.current_sign_in_at
+            @old_last_sign_in_at    = @existing_user.last_sign_in_at
+            @old_sign_in_ip         = @existing_user.current_sign_in_ip
+            @old_last_sign_in_ip    = @existing_user.last_sign_in_ip
+
+            xhr :post, :create, {
+              email: @existing_user.email,
+              password: 'secret123'
+            }
+
+            @resource = assigns(:resource)
+            @data = JSON.parse(response.body)
+
+            @new_sign_in_count      = @resource.sign_in_count
+            @new_current_sign_in_at = @resource.current_sign_in_at
+            @new_last_sign_in_at    = @resource.last_sign_in_at
+            @new_sign_in_ip         = @resource.current_sign_in_ip
+            @new_last_sign_in_ip    = @resource.last_sign_in_ip
           end
 
-          test 'last_sign_in_ip is updated' do
-            refute @old_last_sign_in_ip
-            assert_equal "0.0.0.0", @new_last_sign_in_ip
+          test "request should succeed" do
+            assert_equal 200, response.status
+          end
+
+          test "request should return user data" do
+            assert_equal @existing_user.email, @data['data']['email']
+          end
+
+          describe 'trackable' do
+            test 'sign_in_count incrementns' do
+              assert_equal @old_sign_in_count + 1, @new_sign_in_count
+            end
+
+            test 'current_sign_in_at is updated' do
+              refute @old_current_sign_in_at
+              assert @new_current_sign_in_at
+            end
+
+            test 'last_sign_in_at is updated' do
+              refute @old_last_sign_in_at
+              assert @new_last_sign_in_at
+            end
+
+            test 'sign_in_ip is updated' do
+              refute @old_sign_in_ip
+              assert_equal "0.0.0.0", @new_sign_in_ip
+            end
+
+            test 'last_sign_in_ip is updated' do
+              refute @old_last_sign_in_ip
+              assert_equal "0.0.0.0", @new_last_sign_in_ip
+            end
           end
         end
-      end
 
-      describe 'get sign_in is not supported' do
-        before do
-          xhr :get, :new, {
-            nickname: @existing_user.nickname,
-            password: 'secret123'
-          }
-          @data = JSON.parse(response.body)
+        describe 'get sign_in is not supported' do
+          before do
+            xhr :get, :new, {
+              nickname: @existing_user.nickname,
+              password: 'secret123'
+            }
+            @data = JSON.parse(response.body)
+          end
+
+          test 'user is notified that they should use post sign_in to authenticate' do
+            assert_equal 405, response.status
+          end
+          test "response should contain errors" do
+            assert @data['errors']
+            assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.not_supported")]
+          end
         end
 
-        test 'user is notified that they should use post sign_in to authenticate' do
-          assert_equal 405, response.status
-        end
-        test "response should contain errors" do
-          assert @data['errors']
-          assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.not_supported")]
-        end
-      end
+        describe 'alt auth keys' do
+          before do
+            xhr :post, :create, {
+              nickname: @existing_user.nickname,
+              password: 'secret123'
+            }
+            @data = JSON.parse(response.body)
+          end
 
-      describe 'alt auth keys' do
-        before do
-          xhr :post, :create, {
-            nickname: @existing_user.nickname,
-            password: 'secret123'
-          }
-          @data = JSON.parse(response.body)
+          test 'user can sign in using nickname' do
+            assert_equal 200, response.status
+            assert_equal @existing_user.email, @data['data']['email']
+          end
         end
 
-        test 'user can sign in using nickname' do
-          assert_equal 200, response.status
-          assert_equal @existing_user.email, @data['data']['email']
-        end
-      end
+        describe 'authed user sign out' do
+          before do
+            def @controller.reset_session_called; @reset_session_called == true; end
+            def @controller.reset_session; @reset_session_called = true; end
+            @auth_headers = @existing_user.create_new_auth_token
+            request.headers.merge!(@auth_headers)
+            xhr :delete, :destroy, format: :json
+          end
 
-      describe 'authed user sign out' do
-        before do
-          def @controller.reset_session_called; @reset_session_called == true; end
-          def @controller.reset_session; @reset_session_called = true; end
-          @auth_headers = @existing_user.create_new_auth_token
-          request.headers.merge!(@auth_headers)
-          xhr :delete, :destroy, format: :json
-        end
+          test "user is successfully logged out" do
+            assert_equal 200, response.status
+          end
 
-        test "user is successfully logged out" do
-          assert_equal 200, response.status
-        end
+          test "token was destroyed" do
+            @existing_user.reload
+            refute @existing_user.tokens[@auth_headers["client"]]
+          end
 
-        test "token was destroyed" do
-          @existing_user.reload
-          refute @existing_user.tokens[@auth_headers["client"]]
-        end
-
-        test "session was destroyed" do
-          assert_equal true, @controller.reset_session_called
-        end
-      end
-
-      describe 'unauthed user sign out' do
-        before do
-          @auth_headers = @existing_user.create_new_auth_token
-          xhr :delete, :destroy, format: :json
-          @data = JSON.parse(response.body)
+          test "session was destroyed" do
+            assert_equal true, @controller.reset_session_called
+          end
         end
 
-        test "unauthed request returns 404" do
-          assert_equal 404, response.status
+        describe 'unauthed user sign out' do
+          before do
+            @auth_headers = @existing_user.create_new_auth_token
+            xhr :delete, :destroy, format: :json
+            @data = JSON.parse(response.body)
+          end
+
+          test "unauthed request returns 404" do
+            assert_equal 404, response.status
+          end
+
+          test "response should contain errors" do
+            assert @data['errors']
+            assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.user_not_found")]
+          end
         end
 
-        test "response should contain errors" do
-          assert @data['errors']
-          assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.user_not_found")]
-        end
-      end
+        describe 'failure' do
+          before do
+            xhr :post, :create, {
+              email: @existing_user.email,
+              password: 'bogus'
+            }
 
-      describe 'failure' do
-        before do
-          xhr :post, :create, {
-            email: @existing_user.email,
-            password: 'bogus'
-          }
+            @resource = assigns(:resource)
+            @data = JSON.parse(response.body)
+          end
 
-          @resource = assigns(:resource)
-          @data = JSON.parse(response.body)
-        end
+          test "request should fail" do
+            assert_equal 401, response.status
+          end
 
-        test "request should fail" do
-          assert_equal 401, response.status
-        end
-
-        test "response should contain errors" do
-          assert @data['errors']
-          assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.bad_credentials")]
-        end
-      end
-
-      describe 'failure with bad password when change_headers_on_each_request false' do
-        before do
-          DeviseTokenAuth.change_headers_on_each_request = false
-
-          # accessing current_user calls through set_user_by_token,
-          # which initializes client_id
-          @controller.current_user
-
-          xhr :post, :create, {
-            email: @existing_user.email,
-            password: 'bogus'
-          }
-
-          @resource = assigns(:resource)
-          @data = JSON.parse(response.body)
+          test "response should contain errors" do
+            assert @data['errors']
+            assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.bad_credentials")]
+          end
         end
 
-        test "request should fail" do
-          assert_equal 401, response.status
-        end
+        describe 'failure with bad password when change_headers_on_each_request false' do
+          before do
+            DeviseTokenAuth.change_headers_on_each_request = false
 
-        test "response should contain errors" do
-          assert @data['errors']
-          assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.bad_credentials")]
-        end
+             #accessing current_user calls through set_user_by_token,
+             #which initializes client_id
+            @controller.current_user
 
-        after do
+            xhr :post, :create, {
+              email: @existing_user.email,
+              password: 'bogus'
+            }
+
+            @resource = assigns(:resource)
+            @data = JSON.parse(response.body)
+          end
+
+          test "request should fail" do
+            assert_equal 401, response.status
+          end
+
+          test "response should contain errors" do
+            assert @data['errors']
+            assert_equal @data['errors'], [I18n.t("devise_token_auth.sessions.bad_credentials")]
+          end
+
+          after do
             DeviseTokenAuth.change_headers_on_each_request = true
-        end
-      end
-
-      describe 'case-insensitive email' do
-
-        before do
-          @resource_class = User
-          @request_params = {
-            email: @existing_user.email.upcase,
-            password: 'secret123'
-          }
+          end
         end
 
-        test "request should succeed if configured" do
-          @resource_class.case_insensitive_keys = [:email]
-          xhr :post, :create, @request_params
-          assert_equal 200, response.status
-        end
+        describe 'case-insensitive email' do
 
-        test "request should fail if not configured" do
-          @resource_class.case_insensitive_keys = []
-          xhr :post, :create, @request_params
-          assert_equal 401, response.status
-        end
+          before do
+            @resource_class = User
+            @request_params = {
+              email: @existing_user.email.upcase,
+              password: 'secret123'
+            }
+          end
 
+          test "request should succeed if configured" do
+            @resource_class.case_insensitive_keys = [:email]
+            xhr :post, :create, @request_params
+            assert_equal 200, response.status
+          end
+
+          test "request should fail if not configured" do
+            @resource_class.case_insensitive_keys = []
+            xhr :post, :create, @request_params
+            assert_equal 401, response.status
+          end
+
+        end
       end
     end
 

--- a/test/dummy/db/migrate/20140715061447_devise_token_auth_create_users.rb
+++ b/test/dummy/db/migrate/20140715061447_devise_token_auth_create_users.rb
@@ -50,6 +50,9 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration
         t.text :tokens
       end
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       t.timestamps
     end
 

--- a/test/dummy/db/migrate/20140928231203_devise_token_auth_create_evil_users.rb
+++ b/test/dummy/db/migrate/20140928231203_devise_token_auth_create_evil_users.rb
@@ -48,6 +48,9 @@ class DeviseTokenAuthCreateEvilUsers < ActiveRecord::Migration
         t.text :tokens
       end
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       ## etc.
       t.string :favorite_color
 

--- a/test/dummy/db/migrate/20141222035835_devise_token_auth_create_only_email_users.rb
+++ b/test/dummy/db/migrate/20141222035835_devise_token_auth_create_only_email_users.rb
@@ -48,6 +48,9 @@ class DeviseTokenAuthCreateOnlyEmailUsers < ActiveRecord::Migration
         t.text :tokens
       end
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       t.timestamps
     end
 

--- a/test/dummy/db/migrate/20141222053502_devise_token_auth_create_unregisterable_users.rb
+++ b/test/dummy/db/migrate/20141222053502_devise_token_auth_create_unregisterable_users.rb
@@ -48,6 +48,9 @@ class DeviseTokenAuthCreateUnregisterableUsers < ActiveRecord::Migration
         t.text :tokens
       end
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       t.timestamps
     end
 

--- a/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
+++ b/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
@@ -48,6 +48,9 @@ class DeviseTokenAuthCreateNiceUsers < ActiveRecord::Migration
         t.text :tokens
       end
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       t.timestamps
     end
 

--- a/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
+++ b/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
@@ -48,6 +48,9 @@ class DeviseTokenAuthCreateUnconfirmableUsers < ActiveRecord::Migration
         t.text :tokens
       end
 
+      ## TokenAuthenticatable
+      t.string   :api_token
+
       t.timestamps
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -27,14 +27,15 @@ ActiveRecord::Schema.define(version: 20150708104536) do
     t.string   "confirmation_token",     limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email",      limit: 255
-    t.string   "name",                   limit: 255
-    t.string   "nickname",               limit: 255
-    t.string   "image",                  limit: 255
-    t.string   "provider",               limit: 255
-    t.string   "uid",                    limit: 255,   default: "", null: false
-    t.text     "tokens",                 limit: 65535
-    t.string   "favorite_color",         limit: 255
+    t.string   "unconfirmed_email"
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "provider"
+    t.string   "uid",                    default: "", null: false
+    t.text     "tokens"
+    t.string   "api_token"
+    t.string   "favorite_color"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -98,6 +99,7 @@ ActiveRecord::Schema.define(version: 20150708104536) do
     t.string   "image"
     t.string   "email"
     t.text     "tokens"
+    t.string   "api_token"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -107,14 +109,15 @@ ActiveRecord::Schema.define(version: 20150708104536) do
   add_index "nice_users", ["uid", "provider"], name: "index_nice_users_on_uid_and_provider", unique: true
 
   create_table "only_email_users", force: :cascade do |t|
-    t.string   "provider",           limit: 255,                null: false
-    t.string   "uid",                limit: 255,   default: "", null: false
-    t.string   "encrypted_password", limit: 255,   default: "", null: false
-    t.string   "name",               limit: 255
-    t.string   "nickname",           limit: 255
-    t.string   "image",              limit: 255
-    t.string   "email",              limit: 255
-    t.text     "tokens",             limit: 65535
+    t.string   "provider",                        null: false
+    t.string   "uid",                default: "", null: false
+    t.string   "encrypted_password", default: "", null: false
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "email"
+    t.text     "tokens"
+    t.string   "api_token"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -139,6 +142,7 @@ ActiveRecord::Schema.define(version: 20150708104536) do
     t.string   "image"
     t.string   "email"
     t.text     "tokens"
+    t.string   "api_token"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -162,12 +166,13 @@ ActiveRecord::Schema.define(version: 20150708104536) do
     t.string   "confirmation_token",     limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email",      limit: 255
-    t.string   "name",                   limit: 255
-    t.string   "nickname",               limit: 255
-    t.string   "image",                  limit: 255
-    t.string   "email",                  limit: 255
-    t.text     "tokens",                 limit: 65535
+    t.string   "unconfirmed_email"
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "email"
+    t.text     "tokens"
+    t.string   "api_token"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -191,14 +196,15 @@ ActiveRecord::Schema.define(version: 20150708104536) do
     t.string   "confirmation_token",          limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "confirm_success_url",         limit: 255
-    t.string   "unconfirmed_email",           limit: 255
-    t.string   "name",                        limit: 255
-    t.string   "nickname",                    limit: 255
-    t.string   "image",                       limit: 255
-    t.string   "provider",                    limit: 255
-    t.string   "uid",                         limit: 255,   default: "", null: false
-    t.text     "tokens",                      limit: 65535
+    t.string   "confirm_success_url"
+    t.string   "unconfirmed_email"
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.string   "provider"
+    t.string   "uid",                         default: "", null: false
+    t.text     "tokens"
+    t.string   "api_token"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "operating_thetan",            limit: 4

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -21,6 +21,18 @@ second_confirmed_email_user:
   updated_at:         '<%= timestamp %>'
   encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
 
+<% @api_user_email = Faker::Internet.email %>
+confirmed_api_user:
+  uid:                "<%= @api_user_email %>"
+  email:              "api_stimpy"
+  nickname:           'api stimpy'
+  provider:           'api'
+  confirmed_at:       '<%= timestamp %>'
+  api_token:            <%= SecureRandom.urlsafe_base64(nil, false) %>
+  created_at:         '<%= timestamp %>'
+  updated_at:         '<%= timestamp %>'
+  encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
+
 <% @fb_email = Faker::Internet.email %>
 duplicate_email_facebook_user:
   uid:                "<%= Faker::Number.number(10) %>"


### PR DESCRIPTION
Cover the case where an api consumer (some 3rd party organization) has been given an api key/token rather than email/password that will allow access to the api.

The default is that the request header "Authentication" is used for the token, however, its configurable in the setup block.