### PR TITLE
fix(oauth): fixes #368: do not serialize the entire user object in the url when redirecting from oauth

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -39,7 +39,7 @@ module DeviseTokenAuth
 
       yield if block_given?
 
-      render_data_or_redirect('deliverCredentials', @resource.as_json.merge(@auth_params.as_json))
+      render_data_or_redirect('deliverCredentials', @auth_params.as_json, @resource.as_json)
     end
 
     def omniauth_failure
@@ -190,7 +190,7 @@ module DeviseTokenAuth
       render :layout => nil, :template => "devise_token_auth/omniauth_external_window"
     end
 
-    def render_data_or_redirect(message, data)
+    def render_data_or_redirect(message, data, user_data = {})
 
       # We handle inAppBrowser and newWindow the same, but it is nice
       # to support values in case people need custom implementations for each case
@@ -201,7 +201,7 @@ module DeviseTokenAuth
       # why we can handle these both the same.  The view is setup to handle both cases
       # at the same time.
       if ['inAppBrowser', 'newWindow'].include?(omniauth_window_type)
-        render_data(message, data)
+        render_data(message, user_data.merge(data))
 
       elsif auth_origin_url # default to same-window implementation, which forwards back to auth_origin_url
 


### PR DESCRIPTION
fixes #368 

ng-token-auth is not using this data, so this should be fine for anyone using ng-token-auth.  It is potentially a breaking change if anyone not using ng-token-auth was relying on it, but this functionality has only been around for a few weeks, so hopefully nobody is.