### PR TITLE
Implement login auth key according to Devise wiki

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -5,9 +5,17 @@ module DeviseTokenAuth::Concerns::SetUserByToken
   included do
     before_action :set_request_start
     after_action :update_auth_header
+
+    before_action :default_permitted_parameters, if: :devise_controller?
   end
 
   protected
+
+  def default_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up).concat([:email, :login, :username])
+    devise_parameter_sanitizer.for(:sign_in).concat([:email, :login, :username])
+    devise_parameter_sanitizer.for(:account_update).concat([:email, :username])
+  end
 
   # keep track of request duration
   def set_request_start

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -20,13 +20,21 @@ module DeviseTokenAuth
           q_value.downcase!
         end
 
-        q = "#{field.to_s} = ? AND provider='email'"
+        if field == :login
+          q = "email = ? or nickname = ? AND provider='email'"
+        else
+          q = "#{field.to_s} = ? AND provider='email'"
+        end
 
         if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
           q = "BINARY " + q
         end
 
-        @resource = resource_class.where(q, q_value).first
+        if field == :login
+          @resource = resource_class.where(q, q_value, q_value).first
+        else
+          @resource = resource_class.where(q, q_value).first
+        end
       end
 
       if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -8,6 +8,52 @@ require 'test_helper'
 
 class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
   describe DeviseTokenAuth::SessionsController do
+    describe "Confirmed user using login key" do
+      before do
+        @existing_user = users(:confirmed_email_user)
+        @existing_user.skip_confirmation!
+        @existing_user.save!
+      end
+
+      describe 'success' do
+        before do
+          xhr :post, :create, {
+            login: @existing_user.email,
+            password: 'secret123'
+          }
+
+          @resource = assigns(:resource)
+          @data = JSON.parse(response.body)
+        end
+
+        test "request should succeed" do
+          assert_equal 200, response.status
+        end
+
+        test "request should return user data" do
+          assert_equal @existing_user.email, @data['data']['email']
+        end
+      end
+
+      describe 'login with nickname' do
+        before do
+          xhr :post, :create, {
+            login: @existing_user.nickname,
+            password: 'secret123'
+          }
+          @data = JSON.parse(response.body)
+        end
+
+        test "request should succeed" do
+          assert_equal 200, response.status
+        end
+
+        test "request should return user data" do
+          assert_equal @existing_user.email, @data['data']['email']
+        end
+      end
+    end
+
     describe "Confirmed user" do
       before do
         @existing_user = users(:confirmed_email_user)

--- a/test/dummy/config/initializers/devise.rb
+++ b/test/dummy/config/initializers/devise.rb
@@ -1,3 +1,3 @@
 Devise.setup do |config|
-  config.authentication_keys = [:email, :nickname]
+  config.authentication_keys = [:email, :nickname, :login]
 end


### PR DESCRIPTION
Devise is [capable](https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address) to use email, username or both fields for auth. Currently, Devise Token Auth supports email or username but not both at the same time. This PR is an intention to start the implementation of `login` as an auth key to use the previous fields simultaneously.

This is rather an ad-hoc implementation that makes possible to send a payload with `login` attribute with a valid username or email as its value.

**Important:** this is a proposal based on #127 from which I was inspired for this implementation.

In the few tests written, it seems to be working as expected, but I'm pretty sure that the _SessionsController_ modifications are mostly hard-coded due my lack of knowledge for the field `nickname` on the project.

I'll try to make all the necessary improvements with a bit of guidance.
Please, feel free to throw any critic here and I hope this makes any sense :)

Thanks.
