### PR TITLE
Increment number of sign in and date of sign in after confirmation. S…

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -15,8 +15,10 @@ module DeviseTokenAuth
           expiry: expiry
         }
 
-        @resource.save!
+        sign_in(@resource)
 
+        @resource.save!
+        
         yield if block_given?
 
         redirect_to(@resource.build_auth_url(params[:redirect_url], {
@@ -25,6 +27,7 @@ module DeviseTokenAuth
           account_confirmation_success: true,
           config:                       params[:config]
         }))
+
       else
         raise ActionController::RoutingError.new('Not Found')
       end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -100,7 +100,7 @@ module DeviseTokenAuth
           config:         params[:config]
         }))
       else
-        render_edit_error
+        raise ActionController::RoutingError.new('Not Found')
       end
     end
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -203,7 +203,6 @@ module DeviseTokenAuth::Concerns::User
     DeviseTokenAuth::Url.generate(base_url, args)
   end
 
-
   def extend_batch_buffer(token, client_id)
     self.tokens[client_id]['updated_at'] = Time.now
     self.save!

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,0 +1,30 @@
+pt:
+  devise_token_auth:
+    sessions:
+      not_confirmed: "Uma mensagem com um link de confirmação foi enviado para seu endereço de e-mail. Você precisa confirmar sua conta antes de continuar."
+      bad_credentials: "E-mail ou senha inválidos."
+      not_supported: "Use POST /sign_in para efetuar o login. GET não é suportado."
+      user_not_found: "Utilizador não existe ou não está logado."
+    token_validations:
+      invalid: "Dados de login inválidos."
+    registrations:
+      missing_confirm_success_url: "Parâmetro `confirm_success_url` não informado."
+      redirect_url_not_allowed: "Redirecionamento para %{redirect_url} não permitido."
+      email_already_exists: "Já existe uma conta com o email %{email}."
+      account_with_uid_destroyed: "A conta com uid %{uid} foi excluída."
+      account_to_destroy_not_found: "Não foi possível encontrar a conta para exclusão."
+      user_not_found: "Utilizador não encontrado."
+    passwords:
+      missing_email: "Informe o endereço de e-mail."
+      missing_redirect_url: "URL para redirecionamento não informada."
+      not_allowed_redirect_url: "Redirecionamento para %{redirect_url} não permitido."
+      sended: "Você receberá um e-mail com instruções sobre como redefinir sua senha."
+      user_not_found: "Não existe um utilizador com o e-mail '%{email}'."
+      password_not_required: "Esta conta não necessita de uma senha. Faça login utilizando %{provider}."
+      missing_passwords: 'Preencha a senha e a confirmação de senha.'
+      successfully_updated: "Senha atualizada com sucesso."
+
+  errors:
+    validate_sign_up_params: "Os dados submetidos na requisição de registo são inválidos."
+    validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
+    not_email: "não é um e-mail"


### PR DESCRIPTION
I made 3 changes: 
. Added pt-PT to rep 
. When the user follow the confirmation link, he is automatically logged in. But the login date and login number increment is not updated.  Added sign_in(@resource) to update this information 
. When you visit the change password link for the second time (sent by email), you should be redirected to a 404 page instead of get a window with a json message. 