### PR TITLE
Flag signin when user confirms email address.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    mysql2 (0.3.19)
     nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -250,6 +251,7 @@ DEPENDENCIES
   minitest-rails
   minitest-reporters
   mocha
+  mysql2
   omniauth-facebook!
   omniauth-github!
   omniauth-google-oauth2!
@@ -259,6 +261,3 @@ DEPENDENCIES
   rack-cors
   sqlite3 (~> 1.3)
   thor
-
-BUNDLED WITH
-   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,6 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.19)
     nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -251,7 +250,6 @@ DEPENDENCIES
   minitest-rails
   minitest-reporters
   mocha
-  mysql2
   omniauth-facebook!
   omniauth-github!
   omniauth-google-oauth2!
@@ -261,3 +259,6 @@ DEPENDENCIES
   rack-cors
   sqlite3 (~> 1.3)
   thor
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -15,6 +15,7 @@ module DeviseTokenAuth
           expiry: expiry
         }
 
+        sign_in(@resource)
         @resource.save!
 
         yield if block_given?

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -45,6 +45,16 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
         test "should redirect to success url" do
           assert_redirected_to(/^#{@redirect_url}/)
         end
+
+        test "the sign_in_count should be 1" do
+          assert @resource.sign_in_count == 1
+        end
+        test "User shoud have the signed in info filled" do
+          assert @resource.current_sign_in_at?
+        end
+        test "User shoud have the Last checkin filled" do
+          assert @resource.last_sign_in_at?
+        end
       end
 
       describe "failure" do


### PR DESCRIPTION
When the user follows the confirmation link with success, he automatically sign in to the system.

The information about the number of sign in, the ip etc is not recorded in the database.
This change allows this information to be saved to the database.
