### PR TITLE
404 for invalid link with password reset token

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -100,7 +100,7 @@ module DeviseTokenAuth
           config:         params[:config]
         }))
       else
-        render_edit_error
+        raise ActionController::RoutingError.new('Not Found')
       end
     end
 
@@ -172,12 +172,6 @@ module DeviseTokenAuth
         success: false,
         errors: @errors,
       }, status: @error_status
-    end
-
-    def render_edit_error
-      render json: {
-        success: false
-      }, status: 404
     end
 
     def render_update_error_unauthorized

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -122,13 +122,13 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
           end
 
           describe 'password reset link failure' do
-            test 'respone should return 404' do
-              xhr :get, :edit, {
-                  reset_password_token: 'bogus',
+            test 'response should return 404' do
+              assert_raises(ActionController::RoutingError) {
+                xhr :get, :edit, {
+                  reset_password_token: "bogus",
                   redirect_url: @mail_redirect_url
+                }
               }
-
-              assert_equal 404, response.status
             end
           end
 


### PR DESCRIPTION
When you visit the change password link for the second time (sent by email), you should be redirected to a 404 page instead of get a window with a json message.

This behaviour is also required when you have a wrong password confirmtion link.

