### PR TITLE
fix(url): preserve query parameters when building urls

### DIFF
--- a/lib/devise_token_auth/url.rb
+++ b/lib/devise_token_auth/url.rb
@@ -5,8 +5,9 @@ module DeviseTokenAuth::Url
 
     res = "#{uri.scheme}://#{uri.host}"
     res += ":#{uri.port}" if (uri.port and uri.port != 80 and uri.port != 443)
-    res += "#{uri.path}" if uri.path
-    res += "?#{params.to_query}"
+    res += "#{uri.path}" if uri.path    
+    query = [uri.query, params.to_query].reject(&:blank?).join('&')
+    res += "?#{query}"
     res += "##{uri.fragment}" if uri.fragment
 
     return res

--- a/test/lib/devise_token_auth/url_test.rb
+++ b/test/lib/devise_token_auth/url_test.rb
@@ -7,5 +7,22 @@ class DeviseTokenAuth::UrlTest < ActiveSupport::TestCase
 	    url = 'http://example.com#fragment'
 	    assert_equal DeviseTokenAuth::Url.send(:generate, url, params), "http://example.com?client_id=123#fragment"
 	  end
+
+	  describe 'with existing query params' do
+	  	test 'should preserve existing query params' do
+	      url = 'http://example.com?a=1'
+	      assert_equal DeviseTokenAuth::Url.send(:generate, url), "http://example.com?a=1"
+	    end
+
+	    test 'should marge existing query params with new ones' do
+	      params = {client_id: 123}
+	      url = 'http://example.com?a=1'
+	      assert_equal DeviseTokenAuth::Url.send(:generate, url, params), "http://example.com?a=1&client_id=123"
+	    end
+
+
+	  end
+
+
 	end
 end


### PR DESCRIPTION
When logging in with omniauth, we need to auth_origin_url to include the query params from the original page.  Seems like most people would want this behavior, although in some circumstances this could conceivably be a breaking change.