### PR TITLE
Allow user to specify if validations should run when creating an auth token

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -161,8 +161,8 @@ module DeviseTokenAuth::Concerns::User
 
 
   # update user's auth token (should happen on each request)
-  def create_new_auth_token(options = {})
-    client_id    = options.fetch(:client_id, SecureRandom.urlsafe_base64(nil, false))
+  def create_new_auth_token(client_id=nil, options = {})
+	client_id  ||= SecureRandom.urlsafe_base64(nil, false)
     last_token ||= nil
     token        = SecureRandom.urlsafe_base64(nil, false)
     token_hash   = ::BCrypt::Password.create(token)

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -161,29 +161,29 @@ module DeviseTokenAuth::Concerns::User
 
 
   # update user's auth token (should happen on each request)
-  def create_new_auth_token(client_id=nil)
-    client_id  ||= SecureRandom.urlsafe_base64(nil, false)
+  def create_new_auth_token(options = {})
+    client_id    = options.fetch(:client_id, SecureRandom.urlsafe_base64(nil, false))
     last_token ||= nil
     token        = SecureRandom.urlsafe_base64(nil, false)
     token_hash   = ::BCrypt::Password.create(token)
     expiry       = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    validate_resource = options.fetch(:validate_resource, true)
 
     if self.tokens[client_id] and self.tokens[client_id]['token']
       last_token = self.tokens[client_id]['token']
     end
 
     self.tokens[client_id] = {
-      token:      token_hash,
-      expiry:     expiry,
-      last_token: last_token,
-      updated_at: Time.now
+        token:      token_hash,
+        expiry:     expiry,
+        last_token: last_token,
+        updated_at: Time.now
     }
 
-    self.save!
+    self.save!(validate: validate_resource)
 
     return build_auth_header(token, client_id)
   end
-
 
   def build_auth_header(token, client_id='default')
     client_id ||= 'default'


### PR DESCRIPTION
There are situations that arise when a user gets created but there are required fields on the model (i.e. email), but those values don't get provided when the authentication service (e.g. facebook, github) calls the oauth callback.
