### PR TITLE
Support for i18n in mailers views 

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t(:welcome).capitalize + ' ' + @email %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t '.confirm_link_msg' %> </p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, {confirmation_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url']}).html_safe %></p>
+<p><%= link_to t('.confirm_account_link'), confirmation_url(@resource, {confirmation_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url']}).html_safe %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t '.request_reset_link_msg' %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url'].to_s).html_safe %></p>
+<p><%= link_to t('.password_change_link'), edit_password_url(@resource, reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url'].to_s).html_safe %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t '.ignore_mail_msg' %></p>
+<p><%= t '.no_changes_msg' %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t :hello %> <%= @resource.email %>!</p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t '.account_lock_msg' %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t '.unlock_link_msg' %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token).html_safe %></p>
+<p><%= link_to t('.unlock_link'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -23,10 +23,28 @@ de:
       password_not_required: "Dieser Account benötigt kein Passwort. Melden Sie Sich stattdessen über Ihren Account bei %{provider} an."
       missing_passwords: 'Sie müssen die Felder "Passwort" and "Passwortbestätigung" ausfüllen.'
       successfully_updated: "Ihr Passwort wurde erfolgreich aktualisiert."
-
   errors:
     validate_sign_up_params: "Bitte übermitteln sie vollständige Anmeldeinformationen im Body des Requests."
     validate_account_update_params: "Bitte übermitteln sie vollständige Informationen zur Aktualisierung im Body des Requests."
     not_email: "ist keine E-Mail Adresse"
     messages:
       already_in_use: "bereits in Verwendung"
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "Bestätigungs-"
+        confirm_link_msg: "Sie können Ihr Konto E-Mail über den untenstehenden Link bestätigen:"
+        confirm_account_link: "Ihr Konto zu bestätigen"
+      reset_password_instructions:
+        subject: "Wiederherstellungskennwort Anweisungen"
+        request_reset_link_msg: "Jemand hat einen Link auf Ihr Kennwort zu ändern angefordert. Sie können dies durch den folgenden Link tun:"
+        password_change_link: "Kennwort ändern"
+        ignore_mail_msg: "Wenn Sie nicht angefordert haben diese , ignorieren Sie bitte diese E-Mail:"
+        no_changes_msg: "Ihr Passwort wird nicht geändert , bis Sie auf den obigen Link zugreifen und eine neue erstellen ."
+      unlock_instructions:
+        subject: "entsperren Anweisungen"
+        account_lock_msg: "Ihr Konto wurde aufgrund einer übermäßigen Anzahl von erfolglosen Zeichen in Versuchen gesperrt."
+        unlock_link_msg: "Klicken Sie auf den Link unten , um Ihr Konto zu entsperren :"
+        unlock_link: "Entsperren Sie Ihr Konto "
+  hello: "hallo"
+  welcome: "willkommen"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,10 +23,25 @@ en:
       password_not_required: "This account does not require a password. Sign in using your %{provider} account instead."
       missing_passwords: 'You must fill out the fields labeled "password" and "password confirmation".'
       successfully_updated: "Your password has been successfully updated."
-
   errors:
     validate_sign_up_params: "Please submit proper sign up data in request body."
     validate_account_update_params: "Please submit proper account update data in request body."
     not_email: "is not an email"
     messages:
       already_in_use: already in use
+  devise:
+    mailer:
+      confirmation_instructions:
+        confirm_link_msg: "You can confirm your account email through the link below:"
+        confirm_account_link: Confirm my account
+      reset_password_instructions:
+        request_reset_link_msg: "Someone has requested a link to change your password. You can do this through the link below."
+        password_change_link: Change my password
+        ignore_mail_msg: "If you didn't request this, please ignore this email."
+        no_changes_msg: "Your password won't change until you access the link above and create a new one."
+      unlock_instructions:
+        account_lock_msg: Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+        unlock_link_msg: "Click the link below to unlock your account:"
+        unlock_link: Unlock my account
+  hello: hello
+  welcome: welcome

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -23,10 +23,28 @@ es:
       password_not_required: "Esta cuenta no requiere contraseña. Iniciar sesión utilizando %{provider}."
       missing_passwords: 'Debe llenar los campos "contraseña" y "confirmación de contraseña".'
       successfully_updated: "Su contraseña ha sido actualizada con éxito."
-
   errors:
     validate_sign_up_params: "Los datos introducidos en la solicitud de acceso no son válidos."
     validate_account_update_params: "Los datos introducidos en la solicitud de actualización no son válidos."
     not_email: "no es un correo electrónico"
     messages:
       already_in_use: ya ha sido ocupado
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: Instrucciones de confirmación
+        confirm_link_msg: "Para confirmar su cuenta ingrese en el siguiente link:"
+        confirm_account_link: Confirmar cuenta
+      reset_password_instructions:
+        subject: Instrucciones para restablecer su contraseña
+        request_reset_link_msg: "Ha solicitado un cambio de contraseña. Para continuar ingrese en el siguiente link:"
+        password_change_link: Cambiar contraseña
+        ignore_mail_msg: Por favor ignore este mensaje si no ha solicitado esta acción.
+        no_changes_msg: "Importante: Su contraseña no será actualizada a menos que ingrese en el link."
+      unlock_instructions:
+        subject: Instrucciones de desbloqueo
+        account_lock_msg: Su cuenta ha sido bloqueada debido a sucesivos intentos de ingresos fallidos
+        unlock_link_msg: "Para desbloquear su cuenta ingrese en el siguiente link:"
+        unlock_link: Desbloquear cuenta  
+  hello: hola
+  welcome: bienvenido

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -23,10 +23,28 @@ fr:
       password_not_required: "Ce compte ne demande pas de mot de passe. Connectez vous plutôt en utilisant %{provider}."
       missing_passwords: 'Vous devez remplir les champs "mt de passe" et "confirmation de mot de passe".'
       successfully_updated: "Votre mot de passe a été correctement mis à jour."
-
   errors:
     validate_sign_up_params: "Les données de l'inscription dans le corps de la requête ne sont pas valides."
     validate_account_update_params: "Les données de mise à jour dans le corps de la requête ne sont pas valides."
     not_email: "n'est pas un email"
     messages:
       already_in_use: "déjà utilisé"
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "Les instructions de confirmation"
+        confirm_link_msg: "Vous pouvez confirmer votre compte e-mail via le lien ci-dessous :"
+        confirm_account_link: "Confirmez mon compte"
+      reset_password_instructions:
+        subject: "Instructions de mot de passe de récupération"
+        request_reset_link_msg: "Quelqu'un a demandé un lien pour changer votre mot de passe . Vous pouvez le faire via le lien ci-dessous ."
+        password_change_link: "Changer mon mot de passe"
+        ignore_mail_msg: "Si vous ne l'avez pas demandé cela, s'il vous plaît ignorer cet e-mail ."
+        no_changes_msg: "Votre mot de passe ne changera pas jusqu'à ce que vous accédez au lien ci-dessus et en créer un nouveau ."
+      unlock_instructions:
+        subject: "Instructions à débloquer"
+        account_lock_msg: "Votre compte a été bloqué en raison d' un nombre excessif de signe échec dans les tentatives ."
+        unlock_link_msg: "Cliquez sur le lien ci-dessous pour déverrouiller votre compte :"
+        unlock_link: "Déverrouiller mon compte"
+  hello: bonjour
+  welcome: bienvenue

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -23,10 +23,28 @@ pl:
       password_not_required: "To konto nie wymaga podania hasła. Zaloguj się używając konta %{provider}."
       missing_passwords: 'Musisz wypełnić wszystkie pola z etykietą "hasło" oraz "potwierdzenie hasła".'
       successfully_updated: "Twoje hasło zostało zaktualizowane."
-
   errors:
     validate_sign_up_params: "Proszę dostarczyć odpowiednie dane logowania w ciele zapytania."
     validate_account_update_params: "Proszę dostarczyć odpowiednie dane aktualizacji konta w ciele zapytania."
     not_email: "nie jest prawidłowym adresem e-mail"
     messages:
       already_in_use: "już w użyciu"
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "Instrukcji potwierdzania"
+        confirm_link_msg: "Możesz potwierdzić swój e-mail konta poprzez link poniżej :"
+        confirm_account_link: "Potwierdź swoje konto"
+      reset_password_instructions:
+        subject: "Instrukcje resetowania hasła"
+        request_reset_link_msg: "Ktoś o link do zmiany hasła . Można to zrobić za pośrednictwem linku poniżej ."
+        password_change_link: "Zmień hasło"
+        ignore_mail_msg: "Jeśli jej nie potrzebuję , zignoruj ​​tę wiadomość."
+        no_changes_msg: "Twoje hasło nie zmieni , dopóki dostęp powyższy link i utwórz nowy ."
+      unlock_instructions:
+        subject: "Instrukcje do odblokowania"
+        account_lock_msg: "Twoje konto zostało zablokowane z powodu zbyt dużej liczby nieudanych znak w próbach ."
+        unlock_link_msg: "Kliknij poniższy link, aby odblokować konto :"
+        unlock_link: "Odblokować konto"
+  hello: halo
+  welcome: witam

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -23,10 +23,28 @@ pt-BR:
       password_not_required: "Esta conta não necessita de uma senha. Faça login utilizando %{provider}."
       missing_passwords: 'Preencha a senha e a confirmação de senha.'
       successfully_updated: "Senha atualizada com sucesso."
-
   errors:
     validate_sign_up_params: "Os dados submetidos na requisição de cadastro são inválidos."
     validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
     not_email: "não é um e-mail"
     messages:
       already_in_use: "em uso"
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "Instruções de confirmação"
+        confirm_link_msg: "Você pode confirmar a sua conta de e-mail através do link abaixo :"
+        confirm_account_link: "Confirme conta"
+      reset_password_instructions:
+        subject: "Instruções para redefinir sua senha"
+        request_reset_link_msg: "Alguém pediu um link para mudar sua senha. Você pode fazer isso através do link abaixo "
+        password_change_link: "Alterar a senha"
+        ignore_mail_msg: "Se você não pediu isso, por favor, ignore este e-mail."
+        no_changes_msg: "Sua senha não será alterada até que você acessar o link acima e criar um novo."
+      unlock_instructions:
+        subject: "Instruções de desbloqueio"
+        account_lock_msg: "A sua conta foi bloqueada devido a um número excessivo de sinal de sucesso em tentativas."
+        unlock_link_msg: "Clique no link abaixo para desbloquear sua conta:"
+        unlock_link: "Desbloquear minha conta"
+  hello: "olá"
+  welcome: "bem-vindo"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -23,10 +23,28 @@ pt:
       password_not_required: "Esta conta não necessita de uma senha. Faça login utilizando %{provider}."
       missing_passwords: 'Preencha a senha e a confirmação de senha.'
       successfully_updated: "Senha atualizada com sucesso."
-
   errors:
     validate_sign_up_params: "Os dados submetidos na requisição de registo são inválidos."
     validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
     not_email: "não é um e-mail"
     messages:
       already_in_use: "em uso"
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "Instruções de confirmação"
+        confirm_link_msg: "Você pode confirmar a sua conta de e-mail através do link abaixo :"
+        confirm_account_link: "Confirme conta"
+      reset_password_instructions:
+        subject: "Instruções para redefinir sua senha"
+        request_reset_link_msg: "Alguém pediu um link para mudar sua senha. Você pode fazer isso através do link abaixo "
+        password_change_link: "Alterar a senha"
+        ignore_mail_msg: "Se você não pediu isso, por favor, ignore este e-mail."
+        no_changes_msg: "Sua senha não será alterada até que você acessar o link acima e criar um novo."
+      unlock_instructions:
+        subject: "Instruções de desbloqueio"
+        account_lock_msg: "A sua conta foi bloqueada devido a um número excessivo de sinal de sucesso em tentativas."
+        unlock_link_msg: "Clique no link abaixo para desbloquear sua conta:"
+        unlock_link: "Desbloquear minha conta"
+  hello: "olá"
+  welcome: "bem-vindo"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -23,11 +23,29 @@ ru:
       password_not_required: "Эта учетная запись не требует пароля. Войдите используя учетную запись %{provider}."
       missing_passwords: 'Вы должны заполнить поля "пароль" и "повторите пароль".'
       successfully_updated: "Ваш пароль успешно обновлён."
-
   errors:
     validate_sign_up_params: "Пожалуйста, укажите надлежащие данные для регистрации в теле запроса."
     validate_account_update_params: "Пожалуйста, укажите надлежащие данные для обновления учетной записи в теле запроса."
     not_email: "не является электронной почтой"
     messages:
       already_in_use: "уже используется"
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "Инструкции подтверждения"
+        confirm_link_msg: "Вы можете подтвердить ваш адрес электронной почты через ссылку ниже :"
+        confirm_account_link: Подтвердите свой ​​счет
+      reset_password_instructions:
+        subject: "Инструкции для восстановления пароля"
+        request_reset_link_msg: "Кто-то просил ссылку , чтобы изменить пароль . Вы можете сделать это через ссылку ниже."
+        password_change_link: "Изменить пароль"
+        ignore_mail_msg: "If you didn't request this, please ignore this email."
+        no_changes_msg: "Ваш пароль не изменится, пока вы не открыть ссылку выше и создать новый."
+      unlock_instructions:
+        subject: "Разблокировать Инструкции"
+        account_lock_msg: "Ваш аккаунт был заблокирован из-за чрезмерного количества неудачных попыток в знак ."
+        unlock_link_msg: "Нажмите на ссылку ниже, чтобы разблокировать свой ​​аккаунт :"
+        unlock_link: "Открой свой ​​аккаунт"  
+  hello: "Здравствуйте"
+  welcome: "Добро пожаловат"
 


### PR DESCRIPTION
With the english and spanish respective translations.

I've included the translation for mails subjects in the es.yml (this translation is usually included in [devise translations](https://github.com/plataformatec/devise/wiki/I18n) 'cause ir seems natural to keep al mails views translations together but i'm not sure if is a good practice. Anyway, it's only 3 lines so i've can delete them if request. 

bye