### PR TITLE
Raise error in controller method

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -103,7 +103,7 @@ module DeviseTokenAuth
           config:         params[:config]
         }))
       else
-        raise ActionController::RoutingError.new('Not Found')
+        render_edit_error
       end
     end
 
@@ -177,6 +177,10 @@ module DeviseTokenAuth
         success: false,
         errors: @errors,
       }, status: @error_status
+    end
+
+    def render_edit_error
+      raise ActionController::RoutingError.new('Not Found')
     end
 
     def render_update_error_unauthorized


### PR DESCRIPTION
Upgrading from v0.1.36 to v0.1.37.beta3 I noticed a change in passwords_controller.rb that broke at least my code with regards to #411

Though I agree that it should not show a json object in the browser, our logic and I guess some other projects as well might have overwritten render_edit_error to redirect to a single page app with a more specific error message.

I readded the render_edit_error method to easily override the behavior.