### PR TITLE
Device mapping duplicate method removed

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -1,17 +1,5 @@
 module DeviseTokenAuth
   class ApplicationController < DeviseController
     include DeviseTokenAuth::Concerns::SetUserByToken
-
-    protected
-
-    def resource_class(m=nil)
-      if m
-        mapping = Devise.mappings[m]
-      else
-        mapping = Devise.mappings[resource_name] || Devise.mappings.values.first
-      end
-
-      mapping.to
-    end
   end
 end


### PR DESCRIPTION
Since SetUserByToken concern already has the resource_class method and
application controller is including the same concern, there is no need to
keep the same duplicate method in application controller.