### PR TITLE
Allow resources to auth with multiple methods

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -5,6 +5,8 @@ module DeviseTokenAuth
 
       if @resource and @resource.id
         # create client id
+        #
+        # REVIEW: Why isn't this using resource_class.create_new_auth_token?
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)
         token_hash = BCrypt::Password.create(token)

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -49,6 +49,8 @@ module DeviseTokenAuth
 
           else
             # email auth has been bypassed, authenticate user
+            #
+            # REVIEW: Shouldn't this be calling resource_class.create_new_auth_token?
             @client_id = SecureRandom.urlsafe_base64(nil, false)
             @token     = SecureRandom.urlsafe_base64(nil, false)
 

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -9,37 +9,24 @@ module DeviseTokenAuth
     end
 
     def create
-      # Check
-      field = (resource_params.keys.map(&:to_sym) & resource_class.authentication_keys).first
+      field = resource_class.authentication_field_for(resource_params.keys.map(&:to_sym))
 
-      @resource = nil
       if field
-        q_value = resource_params[field]
-
-        if resource_class.case_insensitive_keys.include?(field)
-          q_value.downcase!
-        end
-
-        q = "#{field.to_s} = ? AND provider='email'"
-
-        if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-          q = "BINARY " + q
-        end
-
-        @resource = resource_class.where(q, q_value).first
+        @resource = resource_class.find_resource(resource_params[field], field)
       end
 
-      if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
-        # create client id
-        @client_id = SecureRandom.urlsafe_base64(nil, false)
-        @token     = SecureRandom.urlsafe_base64(nil, false)
+      if @resource and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
+        auth_values = @resource.create_new_auth_token(nil, resource_params[field], field)
 
-        @resource.tokens[@client_id] = {
-          token: BCrypt::Password.create(@token),
-          expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
-        }
-        @resource.save
+        # These instance variables are required when updating the auth headers
+        # at the end of the request, see:
+        #   DeviseTokenAuth::Concerns::SetUserByToken#update_auth_header
+        @token       = auth_values["access-token"]
+        @client_id   = auth_values["client"]
+        @provider    = "email"
+        @provider_id = @resource.email
 
+        # REVIEW: Shouldn't this be a "mapping" option, rather than a :user?
         sign_in(:user, @resource, store: false, bypass: false)
 
         yield if block_given?
@@ -71,10 +58,6 @@ module DeviseTokenAuth
     end
 
     protected
-
-    def valid_params?(key, val)
-      resource_params[:password] && key && val
-    end
 
     def get_auth_params
       auth_key = nil

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -15,6 +15,9 @@ module DeviseTokenAuth::Concerns::User
   end
 
   included do
+
+    class_variable_set(:@@finder_methods, {})
+
     # Hack to check if devise is already enabled
     unless self.method_defined?(:devise_modules)
       devise :database_authenticatable, :registerable,
@@ -59,6 +62,14 @@ module DeviseTokenAuth::Concerns::User
       false
     end
 
+    def provider
+      if has_attribute?(:provider)
+        read_attribute(:provider)
+      else
+        self.class.authentication_keys.first.to_s
+      end
+    end
+
     # override devise method to include additional info as opts hash
     def send_confirmation_instructions(opts=nil)
       unless @raw_confirmation_token
@@ -93,8 +104,77 @@ module DeviseTokenAuth::Concerns::User
   end
 
   module ClassMethods
-    protected
 
+    # This attempts 4 different finds to try and get the resource, depending on
+    # how the resources have been configured and accounting for backwards
+    # compatibility prior to multiple authentication methods.
+    #
+    def find_resource(id, provider)
+      # 1. If a finder method has been registered for this provider, use it!
+      #
+      finder_method = finder_methods[provider.try(:to_sym)]
+      return finder_method.call(id) if finder_method
+
+      # 2. This check is for backwards compatibility. On introducing multiple
+      #    oauth methods, the uid header changed to include the provider. Prior
+      #    to this change, however, the uid was only the identifier.
+      #    Consequently, if we don't have the provider we fall back to the old
+      #    behaviour of searching by uid. If we don't have a uid (i.e. we're
+      #    allowing multiple auth methods) then we default to something sane.
+      #
+      if provider.nil?
+        field = column_names.include?("uid") ? "uid" : authentication_keys.first
+        return case_sensitive_find("#{field} = ?", id)
+      end
+
+      id.downcase! if self.case_insensitive_keys.include?(provider.to_sym)
+
+      # 3. We then search using {provider: provider, uid: uid} to cover the
+      #    default behaviour which doesn't allow multiple authentication
+      #    methods for a single resource
+      #
+      if column_names.include?("uid") && column_names.include?("provider")
+        resource = case_sensitive_find("uid = ? AND provider = ?", id, provider)
+        return resource if resource
+      end
+
+      # 4. If we're at this point, we've either:
+      #
+      #  A. Got someone who hasn't registered yet
+      #  B. Are using a non-email field to identify users
+      #
+      # If A is the case, we likely won't have a column which corresponds to
+      # the value of "provider" (e.g. "twitter"). Consequently, bail out to
+      # avoid running a query selecting on a column we don't have.
+      #
+      return nil unless column_names.include?(provider.to_s)
+
+      case_sensitive_find("#{provider} = ?", id)
+    end
+
+    def case_sensitive_find(query, *args)
+      if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+        query = "BINARY " + query
+      end
+
+      where(query, *args).first
+    end
+
+    def authentication_field_for(allowed_fields)
+      (allowed_fields & authentication_keys).first
+    end
+
+    # These two methods must use .class_variable_get or the class variable gets
+    # set on this ClassMethods module, instead of the class including it
+    def resource_finder_for(resource, callable)
+      self.class_variable_get(:@@finder_methods)[resource.to_sym] = callable
+    end
+
+    def finder_methods
+      self.class_variable_get(:@@finder_methods)
+    end
+
+    protected
 
     def tokens_has_json_column_type?
       table_exists? && self.columns_hash['tokens'] && self.columns_hash['tokens'].type.in?([:json, :jsonb])
@@ -161,7 +241,7 @@ module DeviseTokenAuth::Concerns::User
 
 
   # update user's auth token (should happen on each request)
-  def create_new_auth_token(client_id=nil)
+  def create_new_auth_token(client_id=nil, provider_id=nil, provider=nil)
     client_id  ||= SecureRandom.urlsafe_base64(nil, false)
     last_token ||= nil
     token        = SecureRandom.urlsafe_base64(nil, false)
@@ -178,21 +258,29 @@ module DeviseTokenAuth::Concerns::User
       last_token: last_token,
       updated_at: Time.now
     }
-	
+
     max_clients = DeviseTokenAuth.max_number_of_devices
     while self.tokens.keys.length > 0 and max_clients < self.tokens.keys.length
       oldest_token = self.tokens.min_by { |cid, v| v[:expiry] || v["expiry"] }
       self.tokens.delete(oldest_token.first)
-    end	
+    end
 
     self.save!
 
-    return build_auth_header(token, client_id)
+    return build_auth_header(token, client_id, provider_id, provider)
   end
 
-
-  def build_auth_header(token, client_id='default')
+  def build_auth_header(token, client_id='default', provider_id, provider)
     client_id ||= 'default'
+
+    # If we've not been given a specific provider, intuit it. This may occur
+    # when logging in through standard devise (for example). See the check
+    # for DeviseTokenAuth.enable_standard_devise_support in:
+    #
+    #  DeviseAuthToken::SetUserToken#set_user_token
+    #
+    provider    = self.class.authentication_keys.first if provider.nil?
+    provider_id = self.send(provider)                  if provider_id.nil?
 
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
@@ -203,10 +291,9 @@ module DeviseTokenAuth::Concerns::User
       "token-type"   => "Bearer",
       "client"       => client_id,
       "expiry"       => expiry.to_s,
-      "uid"          => self.uid
+      "uid"          => "#{provider_id} #{provider}"
     }
   end
-
 
   def build_auth_url(base_url, args)
     args[:uid]    = self.uid
@@ -216,11 +303,11 @@ module DeviseTokenAuth::Concerns::User
   end
 
 
-  def extend_batch_buffer(token, client_id)
+  def extend_batch_buffer(token, client_id, provider_id, provider)
     self.tokens[client_id]['updated_at'] = Time.now
     self.save!
 
-    return build_auth_header(token, client_id)
+    return build_auth_header(token, client_id, provider_id, provider)
   end
 
   def confirmed?
@@ -238,7 +325,9 @@ module DeviseTokenAuth::Concerns::User
 
   # only validate unique email among users that registered by email
   def unique_email_user
-    if provider == 'email' and self.class.where(provider: 'email', email: email).count > 0
+    return true unless self.class.column_names.include?('provider')
+
+    if self.class.where(provider: 'email', email: email).count > 0
       errors.add(:email, :already_in_use)
     end
   end
@@ -248,7 +337,9 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def sync_uid
-    self.uid = email if provider == 'email'
+    if provider == 'email' && has_attribute?(:uid)
+      self.uid = email
+    end
   end
 
   def destroy_expired_tokens

--- a/test/controllers/demo_mang_controller_test.rb
+++ b/test/controllers/demo_mang_controller_test.rb
@@ -61,7 +61,7 @@ class DemoMangControllerTest < ActionDispatch::IntegrationTest
         end
 
         it "should return the user's uid in the auth header" do
-          assert_equal @resource.uid, @resp_uid
+          assert_equal "#{@resource.uid} email", @resp_uid
         end
 
         it 'should not treat this request as a batch request' do

--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -62,7 +62,7 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
         end
 
         it "should return the user's uid in the auth header" do
-          assert_equal @resource.uid, @resp_uid
+          assert_equal "#{@resource.uid} email", @resp_uid
         end
 
         it 'should not treat this request as a batch request' do
@@ -322,8 +322,7 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
           it 'should not define current_mang' do
             refute_equal @resource, @controller.current_mang
           end
-		  
-		  
+
           it 'should increase the number of tokens by a factor of 2 up to 11' do
             @first_token = @resource.tokens.keys.first
 

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -48,7 +48,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
       get_success
       client_id = controller.auth_params[:client_id]
       token = controller.auth_params[:auth_token]
-      expiry = controller.auth_params[:expiry]
+      expiry = controller.auth_params[:expiry].to_i
 
       # the expiry should have been set
       assert_equal expiry, @resource.tokens[client_id][:expiry]
@@ -125,46 +125,63 @@ class OmniauthTest < ActionDispatch::IntegrationTest
     end
 
     describe "oauth registration attr" do
-
-      after do
-        User.any_instance.unstub(:new_record?)
-      end
-
       describe 'with new user' do
-
-        before do
-          User.any_instance.expects(:new_record?).returns(true).at_least_once
-        end
-
-        test 'response contains oauth_registration attr' do
+        test 'registers the new user' do
+          user_count = User.count
 
           get_via_redirect '/auth/facebook', {
             auth_origin_url: @redirect_url,
             omniauth_window_type: 'newWindow'
           }
 
-          assert_equal true, controller.auth_params[:oauth_registration]
+          assert_equal(user_count + 1, User.count)
+        end
+
+        test 'response contains correct attributes' do
+          get_via_redirect '/auth/facebook', {
+            auth_origin_url: @redirect_url,
+            omniauth_window_type: 'newWindow'
+          }
+
+          assert_match(/"oauth_registration":true/, response.body)
+          assert_match(/"email":"chongbong@aol.com"/, response.body)
+          assert_match(/"id":#{User.last.id}/, response.body)
         end
       end
 
       describe 'with existing user' do
-
         before do
-          User.any_instance.expects(:new_record?).returns(false).at_least_once
+          @user = User.create!(
+            provider: 'facebook',
+            uid:      '123545',
+            name:     'chong',
+            email:    'chongbong@aol.com',
+            password: 'somepassword',
+          )
         end
 
-        test 'response does not contain oauth_registration attr' do
+        test 'does not register a new user' do
+          user_count = User.count
 
           get_via_redirect '/auth/facebook', {
             auth_origin_url: @redirect_url,
             omniauth_window_type: 'newWindow'
           }
 
-          assert_equal false, controller.auth_params.key?(:oauth_registration)
+          assert_equal(user_count, User.count)
         end
 
-      end
+        test 'response contains correct attributes' do
+          get_via_redirect '/auth/facebook', {
+            auth_origin_url: @redirect_url,
+            omniauth_window_type: 'newWindow'
+          }
 
+          refute_match(/"oauth_registration":true/, response.body)
+          assert_match(/"email":"#{@user.email}"/, response.body)
+          assert_match(/"id":#{@user.id}/, response.body)
+        end
+      end
     end
 
     describe 'using namespaces' do

--- a/test/dummy/app/controllers/overrides/sessions_controller.rb
+++ b/test/dummy/app/controllers/overrides/sessions_controller.rb
@@ -5,7 +5,7 @@ module Overrides
     def create
       @resource = resource_class.find_by_email(resource_params[:email])
 
-      if @resource and valid_params?(:email, resource_params[:email]) and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
+      if @resource and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
         # create client id
         @client_id = SecureRandom.urlsafe_base64(nil, false)
         @token     = SecureRandom.urlsafe_base64(nil, false)

--- a/test/dummy/app/models/facebook_user.rb
+++ b/test/dummy/app/models/facebook_user.rb
@@ -1,0 +1,3 @@
+class FacebookUser < ActiveRecord::Base
+  has_one :user, class_name: MultiAuthUser
+end

--- a/test/dummy/app/models/multi_auth_user.rb
+++ b/test/dummy/app/models/multi_auth_user.rb
@@ -1,0 +1,11 @@
+class MultiAuthUser < ActiveRecord::Base
+  devise :database_authenticatable, :registerable
+
+  include DeviseTokenAuth::Concerns::User
+
+  resource_finder_for :twitter,  ->(twitter_id)  { find_by(twitter_id: twitter_id) }
+  resource_finder_for :facebook, ->(facebook_id) { FacebookUser.find_by(facebook_id: facebook_id).user }
+
+  belongs_to :facebook_user
+
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
+  resource_finder_for :twitter, ->(twitter_id) { find_by(twitter_id: twitter_id) }
+
   validates :operating_thetan, numericality: true, allow_nil: true
   validate :ensure_correct_favorite_color
 

--- a/test/dummy/db/migrate/20151124151819_add_twitter_id_to_users.rb
+++ b/test/dummy/db/migrate/20151124151819_add_twitter_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddTwitterIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :twitter_id, :integer
+    add_index :users, :twitter_id
+  end
+end

--- a/test/dummy/db/migrate/20151124171407_devise_token_auth_create_multi_auth_users.rb
+++ b/test/dummy/db/migrate/20151124171407_devise_token_auth_create_multi_auth_users.rb
@@ -1,18 +1,18 @@
-class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
-  def change
-    create_table(:<%= user_class.pluralize.underscore %>) do |t|
-      ## Required if using single method authentication per resource. See
-      #  "Single vs Multiple authentication methods per resource" in the README
-      #  for more information.
-      t.string :provider, :null => false, :default => "email"
-      t.string :uid, :null => false, :default => ""
+include MigrationDatabaseHelper
 
+class DeviseTokenAuthCreateMultiAuthUsers < ActiveRecord::Migration
+  # This was largely copied from DeviseTokenAuthCreateUsers
+
+  def change
+    create_table :multi_auth_users do |t|
       ## Database authenticatable
+      t.string :email
       t.string :encrypted_password, :null => false, :default => ""
 
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.string   :reset_password_redirect_url
 
       ## Rememberable
       t.datetime :remember_created_at
@@ -28,6 +28,7 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       t.string   :confirmation_token
       t.datetime :confirmed_at
       t.datetime :confirmation_sent_at
+      t.string   :confirm_success_url
       t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
@@ -39,18 +40,26 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       t.string :name
       t.string :nickname
       t.string :image
-      t.string :email
+
+      ## Identifiers used for allowing users to authenticate multiple ways
+      t.integer :twitter_id
+      t.integer :facebook_user_id
 
       ## Tokens
-      <%= json_supported_database? ? 't.json :tokens' : 't.text :tokens' %>
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
 
       t.timestamps
     end
 
-    add_index :<%= user_class.pluralize.underscore %>, :email
-    add_index :<%= user_class.pluralize.underscore %>, [:uid, :provider],     :unique => true
-    add_index :<%= user_class.pluralize.underscore %>, :reset_password_token, :unique => true
-    # add_index :<%= user_class.pluralize.underscore %>, :confirmation_token,   :unique => true
-    # add_index :<%= user_class.pluralize.underscore %>, :unlock_token,         :unique => true
+    add_index :multi_auth_users, :email
+    add_index :multi_auth_users, :reset_password_token, :unique => true
+    add_index :multi_auth_users, :confirmation_token,   :unique => true
+    add_index :multi_auth_users, :nickname,             :unique => true
+    add_index :multi_auth_users, :twitter_id,           :unique => true
+    add_index :multi_auth_users, :facebook_user_id,     :unique => true
   end
 end

--- a/test/dummy/db/migrate/20151124172214_devise_token_auth_create_create_facebook_users.rb
+++ b/test/dummy/db/migrate/20151124172214_devise_token_auth_create_create_facebook_users.rb
@@ -1,0 +1,9 @@
+class DeviseTokenAuthCreateCreateFacebookUsers < ActiveRecord::Migration
+  def change
+    create_table :facebook_users do |t|
+      t.integer :facebook_id
+    end
+
+    add_index :facebook_users, :facebook_id
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150708104536) do
+ActiveRecord::Schema.define(version: 20151124172214) do
 
   create_table "evil_users", force: :cascade do |t|
     t.string   "email"
@@ -43,6 +43,12 @@ ActiveRecord::Schema.define(version: 20150708104536) do
   add_index "evil_users", ["email"], name: "index_evil_users_on_email"
   add_index "evil_users", ["reset_password_token"], name: "index_evil_users_on_reset_password_token", unique: true
   add_index "evil_users", ["uid", "provider"], name: "index_evil_users_on_uid_and_provider", unique: true
+
+  create_table "facebook_users", force: :cascade do |t|
+    t.integer "facebook_id"
+  end
+
+  add_index "facebook_users", ["facebook_id"], name: "index_facebook_users_on_facebook_id"
 
   create_table "mangs", force: :cascade do |t|
     t.string   "email"
@@ -76,6 +82,40 @@ ActiveRecord::Schema.define(version: 20150708104536) do
   add_index "mangs", ["email"], name: "index_mangs_on_email"
   add_index "mangs", ["reset_password_token"], name: "index_mangs_on_reset_password_token", unique: true
   add_index "mangs", ["uid", "provider"], name: "index_mangs_on_uid_and_provider", unique: true
+
+  create_table "multi_auth_users", force: :cascade do |t|
+    t.string   "email"
+    t.string   "encrypted_password",          default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.string   "reset_password_redirect_url"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",               default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "confirm_success_url"
+    t.string   "unconfirmed_email"
+    t.string   "name"
+    t.string   "nickname"
+    t.string   "image"
+    t.integer  "twitter_id"
+    t.integer  "facebook_user_id"
+    t.text     "tokens"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "multi_auth_users", ["confirmation_token"], name: "index_multi_auth_users_on_confirmation_token", unique: true
+  add_index "multi_auth_users", ["email"], name: "index_multi_auth_users_on_email"
+  add_index "multi_auth_users", ["facebook_user_id"], name: "index_multi_auth_users_on_facebook_user_id", unique: true
+  add_index "multi_auth_users", ["nickname"], name: "index_multi_auth_users_on_nickname", unique: true
+  add_index "multi_auth_users", ["reset_password_token"], name: "index_multi_auth_users_on_reset_password_token", unique: true
+  add_index "multi_auth_users", ["twitter_id"], name: "index_multi_auth_users_on_twitter_id", unique: true
 
   create_table "nice_users", force: :cascade do |t|
     t.string   "provider",                            null: false
@@ -203,12 +243,14 @@ ActiveRecord::Schema.define(version: 20150708104536) do
     t.datetime "updated_at"
     t.integer  "operating_thetan"
     t.string   "favorite_color"
+    t.integer  "twitter_id"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
   add_index "users", ["email"], name: "index_users_on_email"
   add_index "users", ["nickname"], name: "index_users_on_nickname", unique: true
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["twitter_id"], name: "index_users_on_twitter_id"
   add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
 
 end

--- a/test/fixtures/multi_auth_users.yml
+++ b/test/fixtures/multi_auth_users.yml
@@ -1,0 +1,11 @@
+<% timestamp = DateTime.parse(2.weeks.ago.to_s).to_time.strftime("%F %T") %>
+multi_authed_user:
+  email:              '<%= Faker::Internet.email %>'
+  nickname:           'stimpy'
+  twitter_id:         '12345'
+  confirmed_at:       '<%= timestamp %>'
+  created_at:         '<%= timestamp %>'
+  updated_at:         '<%= timestamp %>'
+  encrypted_password: <%= User.new.send(:password_digest, 'secret123') %>
+
+

--- a/test/models/multi_auth_user_test.rb
+++ b/test/models/multi_auth_user_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class MultiAuthUserTest < ActiveSupport::TestCase
+  describe MultiAuthUser do
+    describe '.find_resource' do
+      before do
+        @resource = multi_auth_users(:multi_authed_user)
+        @resource.save!
+      end
+
+      test 'finding the resource with simple custom finder methods for a provider' do
+        found_resource = MultiAuthUser.find_resource(@resource.twitter_id, 'twitter')
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource with complex custom finder methods for a provider' do
+        facebook_user = FacebookUser.create!(facebook_id: 98765)
+        @resource.update_attributes!(facebook_user: facebook_user)
+
+        found_resource = MultiAuthUser.find_resource(facebook_user.facebook_id, 'facebook')
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with no provider' do
+        # Searches just by default authorize key, which in this case is email
+        found_resource = MultiAuthUser.find_resource(@resource.email, nil)
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with no custom finder method for email' do
+        found_resource = MultiAuthUser.find_resource(@resource.email, 'email')
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with a non-email, non-oauth provider' do
+        found_resource = MultiAuthUser.find_resource(@resource.nickname, 'nickname')
+        assert_equal @resource, found_resource
+      end
+    end
+
+    describe 'email uniqueness' do
+      before do
+        email = Faker::Internet.email
+        @resource = MultiAuthUser.create!(
+          email:                 email,
+          password:              'somepassword',
+          password_confirmation: 'somepassword'
+        )
+
+        @new_resource = MultiAuthUser.new(
+          email:                 @resource.email,
+          password:              'anotherpassword',
+          password_confirmation: 'anotherpassword'
+        )
+      end
+
+      # This is to avoid being opinionated about domain objects; who are we to
+      # say that emails should be unique or not? The reason for this test is
+      # that when provider/uid columns are in use, we are opinionated and *do*
+      # care.
+      test 'not validating uniqueness by default' do
+        assert(@new_resource.save)
+      end
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -99,5 +99,68 @@ class UserTest < ActiveSupport::TestCase
         assert @resource.save
       end
     end
+
+    describe '.find_resource' do
+      before do
+        @resource = users(:confirmed_email_user)
+        @resource.skip_confirmation!
+        @resource.save!
+      end
+
+      test 'finding the resource successfully with custom finder methods for a provider' do
+        @resource.update_attributes!(twitter_id: 98765)
+        found_resource = User.find_resource(@resource.twitter_id, 'twitter')
+
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with no provider' do
+        # Searches just by uid, which by default for this resource is email
+        found_resource = User.find_resource(@resource.email, nil)
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with no custom finder method for email' do
+        found_resource = User.find_resource(@resource.email, 'email')
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with no custom finder method for an oauth provider' do
+        @resource.update_attributes!(provider: 'facebook', uid: '12234567')
+        found_resource = User.find_resource(12234567, 'facebook')
+        assert_equal @resource, found_resource
+      end
+
+      test 'finding the resource successfully with a non-email, non-oauth provider' do
+        found_resource = User.find_resource(@resource.nickname, 'nickname')
+        assert_equal @resource, found_resource
+      end
+    end
+
+    describe 'email uniqueness' do
+      before do
+        email = Faker::Internet.email
+        @resource = User.create!(
+          email:                 email,
+          uid:                   email,
+          provider:              'email',
+          password:              'somepassword',
+          password_confirmation: 'somepassword'
+        )
+      end
+
+      test 'creating user with existing email adds an error' do
+        new_resource = User.new(
+          email:                 @resource.email,
+          uid:                   @resource.email,
+          provider:              'email',
+          password:              'anotherpassword',
+          password_confirmation: 'anotherpassword'
+        )
+
+        refute(new_resource.save)
+        assert_includes(new_resource.errors.keys, :email)
+      end
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -127,7 +127,7 @@ class UserTest < ActiveSupport::TestCase
 
       test 'finding the resource successfully with no custom finder method for an oauth provider' do
         @resource.update_attributes!(provider: 'facebook', uid: '12234567')
-        found_resource = User.find_resource(12234567, 'facebook')
+        found_resource = User.find_resource('12234567', 'facebook')
         assert_equal @resource, found_resource
       end
 


### PR DESCRIPTION
# TL;DR

This change allows resources (e.g. User) to authenticate through multiple methods for the same real life person. Prior to this, each auth method (e.g. facebook, twitter, etc) would create a new row in User when it was used.
# Summary

It's inspired off the back of a number of issues raised around multiple authentication methods (particularly with oauth), primarily a longstanding issue #23.  Within that issue there is suggestion of plans A and B, which in short are:
- **Plan A** - A new model will be created for additional 3rd party accounts. This model will have a belongs_to relationship with the original User model.
- **Plan B** - All providers (email + OAuth) exist as belongs_to associations of a core User model. Authentication will be done against the provider models instead of the core User model. 

These are both valid ways of accomplishing this end, so we've largely followed:
- **Plan C** - leave it up to the developer.

We've done this by trying to avoid being opinionated about how users should implement their third party domain objects (e.g. FacebookUser or TwitterUser) and what relationship they may have to the authenticating resource.

For more information on the approach we've taken, check out the README changes we've made, specifically [this section](https://github.com/Twistilled/devise_token_auth/blob/multi_auth_methods_per_resource/README.md#single-vs-multiple-authentication-methods-per-resource).
# Core changes

There are a couple of conceptual changes worth highlighting in this PR:
## 1. Dropping usage of provider/uid columns when allowing multiple auth

The main issue we had with the existing implementation was the reliance on the `provider` and `uid` columns which had to be added to each resource.  It means that whoever uses the gem _must_ model their third party model implementations around these columns in order to have omniauth.  It also had the consequence of real life users potentially ending up with multiple rows in the `users` table, which wasn't something we wanted to allow in our system.
## 2. Restructuring the uid field in the http header

The main thing which we'd like opinions on is the change to the `uid` field.  In the previous implementation, when we call `set_user_by_token`, we would:
1. Pull the `uid` out of the http header
2. Query for the `uid` in the resource table to get the row to authenticate.

We wouldn't need to worry about what `provider` they originally signed in with (e.g. facebook, twitter, email, etc).  However, in order to give developers freedom to decide how they model their third party domain objects (and therefore how they are associated to the resource) we need the `provider` field.

So the big question is how do we pass around the `provider` field between requests?  As we see it, there are three options:
1. Add a new `provider` field to the http token headers
2. Append the `provider` to the existing `uid` value in the http token headers
3. Change the `uid` value in the http token to being the resource's `id`.

A quick table of (what we think) the pros and cons are:

| Option | Pro | Con |
| --- | --- | --- |
| 1 | Simple and clear to implement | Inefficient `resource_finder_for` lambdas are problematic |
|  | `uid` field remains unchanged, so it's _actually_ a `uid` |  |
|  | Easily backwards compatible |  |
| 2 | Clear about what's going on, but not as much as 1 | Polluted `uid` field |
|  | Backwards compatible (in the current implementation) | Inefficient `resource_finder_for` lambdas are problematic |
|  | Already implemented... | May break implementations where people are already storing `uid` in client systems |
| 3 | No danger of inefficient `resource_finder_for` implementatoins | Not easily backwards compatible |
|  |  | Exposes internal `id` fields, which may not be desirable |

We've implemented option 2, but aren't particularly set on it.  The primary reason was a concern about being backwards compatible and not adding more fields to the http header, as there are already quite a few of them.  

Ultimately though, we're leaning towards option 1 now that we've finished the implementation, so input here would be much appreciated!
