### PR TITLE
Move travis to container based configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
+sudo: false
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
Travis CI displays the following message when executing:

`This job ran on our legacy infrastructure. Please read our docs on how to upgrade.`

The new infrastructure is based on containers. The migration doesn't break or change anything to the existing process except running on the currently supported infrastructure.