### PR TITLE
Remove exception from skip_callback

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -36,7 +36,7 @@ module DeviseTokenAuth
 
       begin
         # override email confirmation, must be sent manually from ctrl
-        resource_class.skip_callback("create", :after, :send_on_create_confirmation_instructions)
+        resource_class.skip_callback("create", :after, :send_on_create_confirmation_instructions, raise: false)
         if @resource.save
           yield @resource if block_given?
 


### PR DESCRIPTION
skip_callback will raise an exception if the callback is not set by Devise.
But Devise doesn't always set the callback `send_on_create_confirmation_instructions`, (for example when :confirmable is not present).
In several cases, with the master branch of Devise, we then have an error 500
```
Completed 500 Internal Server Error in 78ms (ActiveRecord: 0.0ms)
ArgumentError (After create callback :send_on_create_confirmation_instructions has not been defined):
...
/Users/jery/.rvm/gems/ruby-2.2.2/bundler/gems/devise_token_auth-d154b0294006/app/controllers/devise_token_auth/registrations_controller.rb:39:in `create'
```
Adding the option :raise to false (as stated in rails documentation), it doesn't raise an exception when the callback has not been set by Devise, and fixes issue #397