### PR TITLE
Remove `skip_before_filter :set_user_by_token` in OmniauthCallbacksController

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -2,7 +2,6 @@ module DeviseTokenAuth
   class OmniauthCallbacksController < DeviseTokenAuth::ApplicationController
 
     attr_reader :auth_params
-    skip_before_filter :set_user_by_token
     skip_after_filter :update_auth_header
 
     # intermediary route for successful omniauth authentication. omniauth does


### PR DESCRIPTION
I believe this is unnecessary? It's throwing an error when starting Sidekiq: `Before process_action callback :set_user_by_token has not been defined`

The stack trace for this error originates from:

`... .rvm/gems/ruby-2.2.3@rails5.0/bundler/gems/devise_token_auth-8a6ba641445e/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb:5:in`class:OmniauthCallbacksController'`
