### PR TITLE
send_on_create_confirmation_instructions callback isn't defined (rails 5)

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -36,6 +36,7 @@ module DeviseTokenAuth
 
       begin
         # override email confirmation, must be sent manually from ctrl
+        resource_class.set_callback("create", :after, :send_on_create_confirmation_instructions)
         resource_class.skip_callback("create", :after, :send_on_create_confirmation_instructions)
         if @resource.save
           yield @resource if block_given?


### PR DESCRIPTION
fixes an issue where send_on_create_confirmation_instructions callback isn't defined.

previously reported on https://github.com/lynndylanhurley/devise_token_auth/pull/496
```
I, [2016-01-23T13:17:10.940856 #23602]  INFO -- : Started POST "/v1/auth" for 10.0.2.2 at 2016-01-23 13:17:10 +0800
I, [2016-01-23T13:17:10.943297 #23602]  INFO -- : Processing by DeviseTokenAuth::RegistrationsController#create as */*
I, [2016-01-23T13:17:10.943428 #23602]  INFO -- :   Parameters: {"name"=>"Patrick Ma", "email"=>"fivetwentysix@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]", "confirm_success_url"=>"https://localhost:4200/login"}
I, [2016-01-23T13:17:11.010024 #23602]  INFO -- : Completed 500 Internal Server Error in 66ms (ActiveRecord: 0.0ms)
F, [2016-01-23T13:17:11.011114 #23602] FATAL -- :
ArgumentError (After create callback :send_on_create_confirmation_instructions has not been defined):
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:641:in `block (2 levels) in skip_callback'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:637:in `each'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:637:in `block in skip_callback'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:568:in `block in __update_callbacks'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:566:in `reverse_each'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:566:in `__update_callbacks'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:636:in `skip_callback'
  /home/pma/.rvm/gems/ruby-2.3.0/bundler/gems/devise_token_auth-cb85c92b2297/app/controllers/devise_token_auth/registrations_controller.rb:41:in `create'
  actionpack (5.0.0.beta1) lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
  actionpack (5.0.0.beta1) lib/abstract_controller/base.rb:183:in `process_action'
  actionpack (5.0.0.beta1) lib/action_controller/metal/rendering.rb:30:in `process_action'
  actionpack (5.0.0.beta1) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:126:in `call'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:455:in `call'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:101:in `__run_callbacks__'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:90:in `run_callbacks'
  actionpack (5.0.0.beta1) lib/abstract_controller/callbacks.rb:19:in `process_action'
  actionpack (5.0.0.beta1) lib/action_controller/metal/rescue.rb:27:in `process_action'
  actionpack (5.0.0.beta1) lib/action_controller/metal/instrumentation.rb:31:in `block in process_action'
  activesupport (5.0.0.beta1) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (5.0.0.beta1) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
  activesupport (5.0.0.beta1) lib/active_support/notifications.rb:164:in `instrument'
  actionpack (5.0.0.beta1) lib/action_controller/metal/instrumentation.rb:29:in `process_action'
  actionpack (5.0.0.beta1) lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
  activerecord (5.0.0.beta1) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (5.0.0.beta1) lib/abstract_controller/base.rb:128:in `process'
  actionpack (5.0.0.beta1) lib/action_controller/metal.rb:192:in `dispatch'
  actionpack (5.0.0.beta1) lib/action_controller/metal.rb:264:in `dispatch'
  actionpack (5.0.0.beta1) lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
  actionpack (5.0.0.beta1) lib/action_dispatch/routing/route_set.rb:32:in `serve'
  actionpack (5.0.0.beta1) lib/action_dispatch/routing/mapper.rb:17:in `block in <class:Constraints>'
  actionpack (5.0.0.beta1) lib/action_dispatch/routing/mapper.rb:47:in `serve'
  actionpack (5.0.0.beta1) lib/action_dispatch/journey/router.rb:42:in `block in serve'
  actionpack (5.0.0.beta1) lib/action_dispatch/journey/router.rb:29:in `each'
  actionpack (5.0.0.beta1) lib/action_dispatch/journey/router.rb:29:in `serve'
  actionpack (5.0.0.beta1) lib/action_dispatch/routing/route_set.rb:715:in `call'
  warden (1.2.4) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.4) lib/warden/manager.rb:34:in `catch'
  warden (1.2.4) lib/warden/manager.rb:34:in `call'
  rack (2.0.0.alpha) lib/rack/etag.rb:25:in `call'
  rack (2.0.0.alpha) lib/rack/conditional_get.rb:38:in `call'
  rack (2.0.0.alpha) lib/rack/head.rb:12:in `call'
  activerecord (5.0.0.beta1) lib/active_record/query_cache.rb:36:in `call'
  activerecord (5.0.0.beta1) lib/active_record/connection_adapters/abstract/connection_pool.rb:963:in `call'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:97:in `__run_callbacks__'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:750:in `_run_call_callbacks'
  activesupport (5.0.0.beta1) lib/active_support/callbacks.rb:90:in `run_callbacks'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
  railties (5.0.0.beta1) lib/rails/rack/logger.rb:42:in `call_app'
  railties (5.0.0.beta1) lib/rails/rack/logger.rb:24:in `block in call'
  activesupport (5.0.0.beta1) lib/active_support/tagged_logging.rb:70:in `block in tagged'
  activesupport (5.0.0.beta1) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (5.0.0.beta1) lib/active_support/tagged_logging.rb:70:in `tagged'
  railties (5.0.0.beta1) lib/rails/rack/logger.rb:24:in `call'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/request_id.rb:24:in `call'
  rack (2.0.0.alpha) lib/rack/runtime.rb:22:in `call'
  activesupport (5.0.0.beta1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  actionpack (5.0.0.beta1) lib/action_dispatch/middleware/load_interlock.rb:13:in `call'
  rack (2.0.0.alpha) lib/rack/sendfile.rb:111:in `call'
  rack-cors (0.4.0) lib/rack/cors.rb:80:in `call'
  railties (5.0.0.beta1) lib/rails/engine.rb:522:in `call'
  rack (2.0.0.alpha) lib/rack/tempfile_reaper.rb:15:in `call'
  rack (2.0.0.alpha) lib/rack/lint.rb:49:in `_call'
  rack (2.0.0.alpha) lib/rack/lint.rb:37:in `call'
  rack (2.0.0.alpha) lib/rack/show_exceptions.rb:23:in `call'
  rack (2.0.0.alpha) lib/rack/common_logger.rb:33:in `call'
  rack (2.0.0.alpha) lib/rack/chunked.rb:54:in `call'
  rack (2.0.0.alpha) lib/rack/content_length.rb:15:in `call'
  puma (2.15.3) lib/puma/server.rb:541:in `handle_request'
  puma (2.15.3) lib/puma/server.rb:388:in `process_client'
  puma (2.15.3) lib/puma/server.rb:270:in `block in run'
  puma (2.15.3) lib/puma/thread_pool.rb:106:in `block in spawn_thread'
```