### PR TITLE
Allow backup identification for account finding

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -17,5 +17,41 @@ module DeviseTokenAuth
 
       mapping.to
     end
+
+    def set_resource(default_identification, value)
+      @resource = nil
+      return unless default_identification.present? && value.present?
+
+      resource_list = [[resource_class.name, default_identification]]
+      backup_identification = resource_params[:backup_field_name]
+      if backup_identification.present?
+        backup_class = resource_params[:backup_field_class]
+        backup_class ||= resource_class.name
+        resource_list << [backup_class, backup_identification]
+      end
+      resource_list.map!{ |tmp_array| tmp_array.map(&:to_s) }
+
+      resource_class_name = resource_class.name.parameterize.to_sym
+      resource_list.each do |(class_name, field_name)|
+        current_class = class_name.classify.constantize
+
+        q = current_class
+        if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+          q = q.where("BINARY #{field_name} = ?", value)
+        else
+          q = q.where(field_name => value)
+        end
+
+        if current_class == resource_class
+          @resource = q.find_by(provider: 'email')
+        else
+          q = q.joins(resource_class_name)
+          current_resource = q.find_by("#{resource_class.table_name}.provider" => 'email')
+          next unless current_resource.present?
+          @resource = current_resource.public_send(resource_class_name)
+        end
+        break if @resource.present?
+      end
+    end
   end
 end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -34,14 +34,7 @@ module DeviseTokenAuth
         @email = resource_params[:email]
       end
 
-      q = "uid = ? AND provider='email'"
-
-      # fix for mysql default case insensitivity
-      if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-        q = "BINARY uid = ? AND provider='email'"
-      end
-
-      @resource = resource_class.where(q, @email).first
+      set_resource('uid', @email)
 
       @errors = nil
       @error_status = 400
@@ -224,7 +217,10 @@ module DeviseTokenAuth
     private
 
     def resource_params
-      params.permit(:email, :password, :password_confirmation, :current_password, :reset_password_token)
+      params.permit(
+        :email, :password, :password_confirmation, :current_password,
+        :reset_password_token, :backup_field_name, :backup_field_class
+      )
     end
 
     def password_resource_params

--- a/test/dummy/app/controllers/overrides/sessions_controller.rb
+++ b/test/dummy/app/controllers/overrides/sessions_controller.rb
@@ -5,7 +5,7 @@ module Overrides
     def create
       @resource = resource_class.find_by_email(resource_params[:email])
 
-      if @resource and valid_params?(:email, resource_params[:email]) and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
+      if @resource and resource_params[:password].present? and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
         # create client id
         @client_id = SecureRandom.urlsafe_base64(nil, false)
         @token     = SecureRandom.urlsafe_base64(nil, false)


### PR DESCRIPTION
Attempt to resolve #509

Do you have any insight on how to test this?

---------

**parameters:**
 + `backup_field_name`: something like `username`
 + `backup_field_class`: something like `user` or `profile` (defaults to `resource_class`)
     - if another class is used, require it to have a direct 1-to-1 association with `resource_class`
     - i.e. `profile.user` must return the user of a profile