### PR TITLE
Prevent raise of exception if set_user_by_token not defined

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ module DeviseTokenAuth
   class OmniauthCallbacksController < DeviseTokenAuth::ApplicationController
 
     attr_reader :auth_params
-    skip_before_action :set_user_by_token
+    skip_before_action :set_user_by_token, raise: false
     skip_after_action :update_auth_header
 
     # intermediary route for successful omniauth authentication. omniauth does


### PR DESCRIPTION
Replicate Rails 4 behavior
Fixes issue #500
You can see that now Rails 5, skip_callback raises an exception if an unrecognized callback is removed
https://github.com/rails/rails/blob/v5.0.0.beta1/activesupport/CHANGELOG.md