### PR TITLE
allow only one confirmation

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -10,11 +10,16 @@ module DeviseTokenAuth
         token_hash = BCrypt::Password.create(token)
         expiry     = (Time.now + DeviseTokenAuth.token_lifespan).to_i
 
+        if @resource.sign_in_count >0 
+          expiry     = (Time.now + 1.second).to_i
+        end
+        
         @resource.tokens[client_id] = {
           token:  token_hash,
           expiry: expiry
         }
 
+        sign_in(@resource)
         @resource.save!
 
         yield if block_given?

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -45,6 +45,21 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
         test "should redirect to success url" do
           assert_redirected_to(/^#{@redirect_url}/)
         end
+
+        test "the sign_in_count should be 1" do
+          assert @resource.sign_in_count == 1
+        end
+        test "User shoud have the signed in info filled" do
+          assert @resource.current_sign_in_at?
+        end
+        test "User shoud have the Last checkin filled" do
+          assert @resource.last_sign_in_at?
+        end
+        test "user already confirmed" do 
+          assert @resource.sign_in_count > 0 do 
+            assert expiry == (Time.now + Time.now + 1.second).to_i
+          end
+        end
       end
 
       describe "failure" do


### PR DESCRIPTION
When a user confirms and account (after a registration), if the registration is valid, the user is logged in automatically in the system. 

After a successful confirmation the user can still use the confirmation email to login into the system (without a password) and this represents a security flaw. 

If the token is valid and if the user is already confirmed, the devise_token_auth should return an expired token. This will raise an auth:email-confirmation-error in ng-token-auth. 

This will require #410 because it looks for sign_in counter.
