### PR TITLE
Avoid sending auth headers if while processing used token is cleared

### DIFF
--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -321,11 +321,40 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
             get '/demo/members_only', {}, @old_auth_headers
             assert 401, response.status
           end
-          
+
         end
 
       end
 
+      describe 'request including destroy of token' do
+        describe 'when change_headers_on_each_request is set to false' do
+          before do
+            DeviseTokenAuth.change_headers_on_each_request = false
+            age_token(@resource, @client_id)
+
+            get '/demo/members_only_remove_token', {}, @auth_headers
+          end
+
+          after do
+            DeviseTokenAuth.change_headers_on_each_request = true
+          end
+
+          it 'should not return auth-headers' do
+            refute response.headers['access-token']
+          end
+        end
+
+        describe 'when change_headers_on_each_request is set to true' do
+          before do
+            age_token(@resource, @client_id)
+            get '/demo/members_only_remove_token', {}, @auth_headers
+          end
+
+          it 'should not return auth-headers' do
+            refute response.headers['access-token']
+          end
+        end
+      end
     end
 
     describe 'enable_standard_devise_support' do
@@ -364,8 +393,8 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
           it 'should not define current_mang' do
             refute_equal @resource, @controller.current_mang
           end
-		  
-		  
+
+
           it 'should increase the number of tokens by a factor of 2 up to 11' do
             @first_token = @resource.tokens.keys.first
 
@@ -459,6 +488,5 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
       end
 
     end
-
   end
 end

--- a/test/dummy/app/controllers/demo_user_controller.rb
+++ b/test/dummy/app/controllers/demo_user_controller.rb
@@ -9,4 +9,17 @@ class DemoUserController < ApplicationController
       }
     }, status: 200
   end
+
+  def members_only_remove_token
+    u = User.find(current_user.id)
+    u.tokens = {}
+    u.save!
+
+    render json: {
+      data: {
+        message: "Welcome #{current_user.name}",
+        user: current_user
+      }
+    }, status: 200
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -56,6 +56,8 @@ Rails.application.routes.draw do
 
   # this route will authorize visitors using the User class
   get 'demo/members_only', to: 'demo_user#members_only'
+  get 'demo/members_only_remove_token', to: 'demo_user#members_only_remove_token'
+
 
   # routes within this block will authorize visitors using the Mang class
   get 'demo/members_only_mang', to: 'demo_mang#members_only'


### PR DESCRIPTION
This pull request fix the error occurred in following scenario:

1. Client sends request R1 and server starts processing it
2. Client sends sign out request R2 and server process it (R1 still processing)
3. R1 finishes. Its response to the server will contain auth headers, although user already signed out.

To avoid R1 response containing auth headers, in the after action code, it should be checked that the token had not been removed in the meantime. 

