### PR TITLE
Use correct message when active_for_authentication? fails

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -115,7 +115,7 @@ module DeviseTokenAuth
     def render_create_error_not_confirmed
       render json: {
         success: false,
-        errors: [ I18n.t("devise_token_auth.sessions.not_confirmed", email: @resource.email) ]
+        errors: [ I18n.t("devise_token_auth.sessions.#{@resource.inactive_message}", email: @resource.email) ]
       }, status: 401
     end
 


### PR DESCRIPTION
This way a user can overload User#active_for_authentication? and User#inactive_message and the correct error message will be returned by the sessions controller.
