### PR TITLE
Add create action to confirmations for consistency

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -1,33 +1,84 @@
 module DeviseTokenAuth
   class ConfirmationsController < DeviseTokenAuth::ApplicationController
-    def show
-      @resource = resource_class.confirm_by_token(params[:confirmation_token])
 
-      if @resource and @resource.id
-        # create client id
-        client_id  = SecureRandom.urlsafe_base64(nil, false)
-        token      = SecureRandom.urlsafe_base64(nil, false)
-        token_hash = BCrypt::Password.create(token)
-        expiry     = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    before_action :setup_confirmation, :only => [:create, :show]
 
-        @resource.tokens[client_id] = {
-          token:  token_hash,
-          expiry: expiry
-        }
+    def create
+      return unless @successful_confirmation
+      yield if block_given?
 
-        @resource.save!
-
-        yield if block_given?
-
-        redirect_to(@resource.build_auth_url(params[:redirect_url], {
-          token:                        token,
-          client_id:                    client_id,
-          account_confirmation_success: true,
-          config:                       params[:config]
-        }))
-      else
-        raise ActionController::RoutingError.new('Not Found')
-      end
+      update_auth_header
+      render_create_success
     end
+
+    def show
+      return unless @successful_confirmation
+      yield if block_given?
+
+      redirect_to(@resource.build_auth_url(params[:redirect_url], {
+        token:                        @token,
+        client_id:                    @client_id,
+        account_confirmation_success: true,
+        config:                       params[:config]
+      }))
+    end
+
+    private
+
+      def setup_confirmation
+        @successful_confirmation = false
+
+        @resource = get_resource
+
+        render_create_error_invalid_resource && return \
+          unless @resource.present?
+
+        create_resource_token
+
+        render_create_error && return \
+          unless @resource.save
+
+        @successful_confirmation = true
+      end
+
+      def get_resource
+        resource = resource_class.confirm_by_token(params[:confirmation_token])
+        resource = nil unless resource.try(:id).present?
+        resource
+      end
+
+      def create_resource_token
+        # create client id and token
+        @client_id = SecureRandom.urlsafe_base64(nil, false)
+        @token     = SecureRandom.urlsafe_base64(nil, false)
+
+        # store client + token in user's token hash
+        @resource.tokens[@client_id] = {
+          token: BCrypt::Password.create(@token),
+          expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+        }
+      end
+
+      def render_create_success
+        render json: {
+          success: true,
+          data: @resource.token_validation_response
+        }
+      end
+
+      def render_create_error_invalid_resource
+        render json: {
+          success: false,
+          errors: [I18n.t("devise_token_auth.confirmations.bad_token")]
+        }, status: 401
+      end
+
+      def render_create_error
+        render json: {
+          success: false,
+          errors: resource_errors
+        }, status: 422
+      end
+
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
       password_not_required: "This account does not require a password. Sign in using your '%{provider}' account instead."
       missing_passwords: "You must fill out the fields labeled 'Password' and 'Password confirmation'."
       successfully_updated: "Your password has been successfully updated."
+    confirmations:
+      bad_token: "Invalid confirmation token. Please try email link again."
   errors:
     messages:
       already_in_use: "already in use"

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -32,7 +32,7 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
         assert @new_user.confirmation_token
       end
 
-      describe "success" do
+      describe "show success" do
         before do
           xhr :get, :show, {confirmation_token: @token, redirect_url: @redirect_url}
           @resource = assigns(:resource)
@@ -49,13 +49,33 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
 
       describe "failure" do
         test "user should not be confirmed" do
-          assert_raises(ActionController::RoutingError) {
-            xhr :get, :show, {confirmation_token: "bogus"}
-          }
-          @resource = assigns(:resource)
-          refute @resource.confirmed?
+          xhr :get, :show, {confirmation_token: "bogus"}
+          assert_equal 401, response.status
         end
       end
+
+      describe "create success" do
+        before do
+          xhr :get, :create, {confirmation_token: @token, redirect_url: @redirect_url}
+          @resource = assigns(:resource)
+        end
+
+        test "user should now be confirmed" do
+          assert @resource.confirmed?
+        end
+
+        test "should redirect to success url" do
+          assert_equal 200, response.status
+        end
+      end
+
+      describe "failure" do
+        test "user should not be confirmed" do
+          xhr :get, :create, {confirmation_token: "bogus"}
+          assert_equal 401, response.status
+        end
+      end
+
     end
 
     # test with non-standard user class


### PR DESCRIPTION
Resolves: #546

---

I tried to match the create action to be consistent with the rest of the controllers.

I did however leave the show action in case anyone was still using it for legacy purposes
