### PR TITLE
DeviseTokenAuth.enable_standard_devise_support changes

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -37,7 +37,6 @@ module DeviseTokenAuth::Concerns::SetUserByToken
       if devise_warden_user && devise_warden_user.tokens[@client_id].nil?
         @used_auth_by_token = false
         @resource = devise_warden_user
-        @resource.create_new_auth_token
       end
     end
 
@@ -56,7 +55,6 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     user = uid && rc.find_by_uid(uid)
 
     if user && user.valid_token?(@token, @client_id)
-      sign_in(:user, user, store: false, bypass: true)
       return @resource = user
     else
       # zero all values previously set values


### PR DESCRIPTION
Calling `@resource.create_new_auth_token` simply ends up revoking older tokens on every request since the web (legacy devise) ends up using this part of the code.

Also, we ran into problems with the `sign_in` call not using the `mapping` variable for the first parameter. Additionally, a devise bug when using both `store: false` and `bypass: true` (https://github.com/plataformatec/devise/issues/3981) causes the user object to be stored in the session which will not be used since it was an API request to begin with. This bloats our redis memory usage significantly (we have a large user model).
