### PR TITLE
User concern: Ensure fallback is in place

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -70,6 +70,7 @@ module DeviseTokenAuth::Concerns::User
       if pending_reconfirmation?
         opts[:to] = unconfirmed_email
       end
+      opts[:redirect_url] ||= DeviseTokenAuth.default_confirm_success_url
 
       send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
     end

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -8,6 +8,12 @@ require 'test_helper'
 
 class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
   describe DeviseTokenAuth::ConfirmationsController do
+    def token_and_client_config_from(body)
+      token         = body.match(/confirmation_token=([^&]*)&/)[1]
+      client_config = body.match(/config=([^&]*)&/)[1]
+      [token, client_config]
+    end
+
     describe "Confirmation" do
       before do
         @redirect_url = Faker::Internet.url
@@ -15,9 +21,8 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
         @new_user.send_confirmation_instructions({
           redirect_url: @redirect_url
         })
-        @mail          = ActionMailer::Base.deliveries.last
-        @token         = @mail.body.match(/confirmation_token=([^&]*)&/)[1]
-        @client_config = @mail.body.match(/config=([^&]*)&/)[1]
+        mail = ActionMailer::Base.deliveries.last
+        @token, @client_config = token_and_client_config_from(mail.body)
       end
 
       test 'should generate raw token' do
@@ -74,9 +79,8 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
 
         @new_user.send_confirmation_instructions(client_config: @config_name)
 
-        @mail          = ActionMailer::Base.deliveries.last
-        @token         = @mail.body.match(/confirmation_token=(.*)\"/)[1]
-        @client_config = @mail.body.match(/config=(.*)\&/)[1]
+        mail = ActionMailer::Base.deliveries.last
+        @token, @client_config = token_and_client_config_from(mail.body)
       end
 
       test 'should generate raw token' do


### PR DESCRIPTION
Without this change "redirect_url" may be blank, leading to an internal bad URI error unless set when confirming.

Occurs when creating a user from the Rails console, for instance.

**Workaround**: implement the `#send_confirmation_instructions` method in your User model, with the `opts[:redirect_url] ||= DeviseTokenAuth.default_confirm_success_url` line in there.