### PR TITLE
now possible to change headers names in the config file

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -23,10 +23,15 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     # no default user defined
     return unless rc
 
+    #gets the headers names, which was set in the initilize file
+    uid_name = DeviseTokenAuth.headers_names[:'uid']
+    access_token_name = DeviseTokenAuth.headers_names[:'access-token']
+    client_name = DeviseTokenAuth.headers_names[:'client']
+
     # parse header for values necessary for authentication
-    uid        = request.headers['uid'] || params['uid']
-    @token     = request.headers['access-token'] || params['access-token']
-    @client_id = request.headers['client'] || params['client']
+    uid        = request.headers[uid_name] || params[uid_name]
+    @token     = request.headers[access_token_name] || params[access_token_name]
+    @client_id = request.headers[client_name] || params[client_name]
 
     # client_id isn't required, set to 'default' if absent
     @client_id ||= 'default'

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -200,11 +200,11 @@ module DeviseTokenAuth::Concerns::User
       expiry = self.tokens[client_id]['expiry'] || self.tokens[client_id][:expiry]
   
       return {
-        "access-token" => token,
-        "token-type"   => "Bearer",
-        "client"       => client_id,
-        "expiry"       => expiry.to_s,
-        "uid"          => self.uid
+        DeviseTokenAuth.headers_names[:"access-token"] => token,
+        DeviseTokenAuth.headers_names[:"token-type"]   => "Bearer",
+        DeviseTokenAuth.headers_names[:"client"]       => client_id,
+        DeviseTokenAuth.headers_names[:"expiry"]       => expiry.to_s,
+        DeviseTokenAuth.headers_names[:"uid"]          => self.uid
       }
     end
   end

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -20,7 +20,8 @@ module DeviseTokenAuth
                  :check_current_password_before_update,
                  :enable_standard_devise_support,
                  :remove_tokens_after_password_reset,
-                 :default_callbacks
+                 :default_callbacks,
+                 :headers_names
 
   self.change_headers_on_each_request       = true
   self.max_number_of_devices                = 10
@@ -34,6 +35,11 @@ module DeviseTokenAuth
   self.enable_standard_devise_support       = false
   self.remove_tokens_after_password_reset   = false
   self.default_callbacks                    = true
+  self.headers_names                        = {:'access-token' => 'access-token',
+                                               :'client' => 'client',
+                                               :'expiry' => 'expiry',
+                                               :'uid' => 'uid',
+                                               :'token-type' => 'token-type' }
 
   def self.setup(&block)
     yield self

--- a/lib/generators/devise_token_auth/templates/devise_token_auth.rb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth.rb
@@ -34,6 +34,13 @@ DeviseTokenAuth.setup do |config|
   # It depends on fields like email, provider and uid.
   # config.default_callbacks = true
 
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can
   # do so by enabling this flag. NOTE: This feature is highly experimental!

--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -355,6 +355,27 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
           end
         end
       end
+
+      describe 'when access-token name has been changed' do
+        before do
+          # ensure that request is not treated as batch request
+          DeviseTokenAuth.headers_names[:'access-token'] = 'new-access-token'
+          auth_headers_modified = @resource.create_new_auth_token
+          client_id = auth_headers_modified['client']
+          age_token(@resource, client_id)
+
+          get '/demo/members_only', {}, auth_headers_modified
+          @resp_token = response.headers['new-access-token']
+        end
+
+        it 'should have "new-access-token" header' do
+          assert @resp_token.present?
+        end
+
+        after do
+          DeviseTokenAuth.headers_names[:'access-token'] = 'access-token'
+        end
+      end
     end
 
     describe 'enable_standard_devise_support' do


### PR DESCRIPTION
Would be very handy to change the headers names because, for example, `expiry` conflicts with another expiry which is coming from a different project.