### PR TITLE
allowing authenticating using headers as well as a post request

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -17,6 +17,9 @@ module DeviseTokenAuth
     protected
 
     def params_for_resource(resource)
+      devise_parameter_sanitizer.instance_values['permitted'][resource].each do |type|
+        params[type.to_s] ||= request.headers[type.to_s] unless request.headers[type.to_s].nil?
+      end
       devise_parameter_sanitizer.instance_values['permitted'][resource]
     end
 

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -91,6 +91,21 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
         end
       end
 
+      describe 'header sign_in is supported' do
+        before do
+          request.headers.merge!(
+            'email' => @existing_user.email,
+            'password' => 'secret123')
+
+          xhr :head, :create
+          @data = JSON.parse(response.body)
+        end
+
+        test 'user can sign in using header request' do
+          assert_equal 200, response.status
+        end
+      end
+
       describe 'alt auth keys' do
         before do
           xhr :post, :create, {


### PR DESCRIPTION
For some system, all post request data is logged in the system. When there is no possible way to change that, it's much nicer to be able to send the user email and password via the header instead of a data string in a post request. Therefore, instead of sending

```bash
curl -s -X POST -d 'email=some@cool.com&password=partypassword' -D -  'https://theurl.com/api/v1/auth/sign_in' -o /dev/null 2>&1
```

we can do

```bash
curl -s -X POST -H 'email: some@cool.com' -H 'password: partypassword' -D -  'https://theurl.com/api/v1/auth/sign_in' -o /dev/null 2>&1
```