### PR TITLE
Modified condition to apply unique_email_user validation

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -6,23 +6,22 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
     validates_presence_of :uid, if: Proc.new { |u| u.provider != 'email' }
 
     # only validate unique emails among email registration users
-    validate :unique_email_user, on: :create
+    validate :unique_email_user, if: Proc.new { |u| u.provider == 'email' && u.email_change }
 
     # keep uid in sync with email
-    before_save :sync_uid
-    before_create :sync_uid
+    before_save :sync_uid, if: Proc.new { |u| u.provider == 'email' }
   end
 
   protected
 
   # only validate unique email among users that registered by email
   def unique_email_user
-    if provider == 'email' and self.class.where(provider: 'email', email: email).count > 0
+    if self.class.where(provider: 'email', email: email).exists?
       errors.add(:email, I18n.t("errors.messages.already_in_use"))
     end
   end
 
   def sync_uid
-    self.uid = email if provider == 'email'
+    self.uid = email
   end
 end


### PR DESCRIPTION
`before_create :sync_uid` is not needed as `before_save :sync_uid` is already defined.

Moved conditions out from `unique_email_user` and `sync_uid`, so that anyone overriding these methods wouldn't have to take care of those conditions.

Updated condition on which to apply `unique_email_user` validation. It was only being validated _on create_, while it should be applied whenever _email is changed_.
