### PR TITLE
fixed devise deprecation warning for config.email_regexp

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -142,7 +142,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  # config.email_regexp = /\A[^@]+@[^@]+\z/
+  config.email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\W]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
Fixed deprecation warning:
 
> DEPRECATION WARNING: [Devise] config.email_regexp will have a new default on Devise 4.1

Issue occurs when using devise_token_auth with devise 4.0.0
Fix: Kept the current behavior for devise 4.0.0 
```	
Devise.setup do |config|
 config.email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\W]+\z/
end