### PR TITLE
Fix yields from controller actions

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -17,7 +17,7 @@ module DeviseTokenAuth
 
         @resource.save!
 
-        yield if block_given?
+        yield @resource if block_given?
 
         redirect_to(@resource.build_auth_url(params[:redirect_url], {
           token:                        token,

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -38,7 +38,7 @@ module DeviseTokenAuth
 
       @resource.save!
 
-      yield if block_given?
+      yield @resource if block_given?
 
       render_data_or_redirect('deliverCredentials', @auth_params.as_json, @resource.as_json)
     end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -47,7 +47,7 @@ module DeviseTokenAuth
       @error_status = 400
 
       if @resource
-        yield if block_given?
+        yield @resource if block_given?
         @resource.send_reset_password_instructions({
           email: @email,
           provider: 'email',
@@ -94,7 +94,7 @@ module DeviseTokenAuth
         @resource.allow_password_change = true;
 
         @resource.save!
-        yield if block_given?
+        yield @resource if block_given?
 
         redirect_to(@resource.build_auth_url(params[:redirect_url], {
           token:          token,
@@ -126,7 +126,7 @@ module DeviseTokenAuth
       if @resource.send(resource_update_method, password_resource_params)
         @resource.allow_password_change = false
 
-        yield if block_given?
+        yield @resource if block_given?
         return render_update_success
       else
         return render_update_error

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -42,7 +42,7 @@ module DeviseTokenAuth
 
         sign_in(:user, @resource, store: false, bypass: false)
 
-        yield if block_given?
+        yield @resource if block_given?
 
         render_create_success
       elsif @resource and not (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
@@ -62,7 +62,7 @@ module DeviseTokenAuth
         user.tokens.delete(client_id)
         user.save!
 
-        yield if block_given?
+        yield user if block_given?
 
         render_destroy_success
       else

--- a/app/controllers/devise_token_auth/token_validations_controller.rb
+++ b/app/controllers/devise_token_auth/token_validations_controller.rb
@@ -6,7 +6,7 @@ module DeviseTokenAuth
     def validate_token
       # @resource will have been set by set_user_token concern
       if @resource
-        yield if block_given?
+        yield @resource if block_given?
         render_validate_token_success
       else
         render_validate_token_error

--- a/test/dummy/app/controllers/custom/confirmations_controller.rb
+++ b/test/dummy/app/controllers/custom/confirmations_controller.rb
@@ -2,7 +2,7 @@ class Custom::ConfirmationsController < DeviseTokenAuth::ConfirmationsController
 
   def show
     super do |resource|
-      @show_block_called = true
+      @show_block_called = true unless resource.nil?
     end
   end
 

--- a/test/dummy/app/controllers/custom/omniauth_callbacks_controller.rb
+++ b/test/dummy/app/controllers/custom/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class Custom::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksCo
 
   def omniauth_success
     super do |resource|
-      @omniauth_success_block_called = true
+      @omniauth_success_block_called = true unless resource.nil?
     end
   end
 

--- a/test/dummy/app/controllers/custom/passwords_controller.rb
+++ b/test/dummy/app/controllers/custom/passwords_controller.rb
@@ -2,19 +2,19 @@ class Custom::PasswordsController < DeviseTokenAuth::PasswordsController
 
   def create
     super do |resource|
-      @create_block_called = true
+      @create_block_called = true unless resource.nil?
     end
   end
 
   def edit
     super do |resource|
-      @edit_block_called = true
+      @edit_block_called = true unless resource.nil?
     end
   end
 
   def update
     super do |resource|
-      @update_block_called = true
+      @update_block_called = true unless resource.nil?
     end
   end
 

--- a/test/dummy/app/controllers/custom/registrations_controller.rb
+++ b/test/dummy/app/controllers/custom/registrations_controller.rb
@@ -8,13 +8,13 @@ class Custom::RegistrationsController < DeviseTokenAuth::RegistrationsController
 
   def update
     super do |resource|
-      @update_block_called = true
+      @update_block_called = true unless resource.nil?
     end
   end
 
   def destroy
     super do |resource|
-      @destroy_block_called = true
+      @destroy_block_called = true unless resource.nil?
     end
   end
 

--- a/test/dummy/app/controllers/custom/sessions_controller.rb
+++ b/test/dummy/app/controllers/custom/sessions_controller.rb
@@ -2,13 +2,13 @@ class Custom::SessionsController < DeviseTokenAuth::SessionsController
 
   def create
     super do |resource|
-      @create_block_called = true
+      @create_block_called = true unless resource.nil?
     end
   end
 
   def destroy
     super do |resource|
-      @destroy_block_called = true
+      @destroy_block_called = true unless resource.nil?
     end
   end
 

--- a/test/dummy/app/controllers/custom/token_validations_controller.rb
+++ b/test/dummy/app/controllers/custom/token_validations_controller.rb
@@ -2,7 +2,7 @@ class Custom::TokenValidationsController < DeviseTokenAuth::TokenValidationsCont
 
   def validate_token
     super do |resource|
-      @validate_token_block_called = true
+      @validate_token_block_called = true unless resource.nil?
     end
   end
 


### PR DESCRIPTION
So let me start by saying that this is my first PR to a ruby gem. So, if it's useless/crap, feel free to tell me so (gently).

The problem comes from the following example: https://github.com/lynndylanhurley/devise_token_auth#passing-blocks-to-controllers

Currently only the registration controller seems to be yielding properly (that is, something at all). All other controller actions seem to not yield anything.
I added the tests to back my theory up, along with the fairly simple fixes.

Heads up to session/destroy action, which is yielding 'user', not '@resource'. 