### PR TITLE
Updating Devise dependency to max 4.1.1

### DIFF
--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files.reject! { |file| file.match(/[.log|.sqlite3]$/) }
 
   s.add_dependency "rails", "< 6"
-  s.add_dependency "devise", "> 3.5.2", "< 4.1"
+  s.add_dependency "devise", "> 3.5.2", "< 4.1.1"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency 'pg'


### PR DESCRIPTION
Updating devise dependency to 4.1.1 from 4.1 mk2