### PR TITLE
updates config wrapper to conform with multiple versions of Active Model Serializers

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -35,6 +35,8 @@ module DeviseTokenAuth
 
     def is_json_api
       return false unless defined?(ActiveModel::Serializer)
+      # 0.10.0 branch of ActiveModel:Serializer does not respond to :setup block. Use alternate syntax
+      return ActiveModel::Serializer.config.adapter == :json_api unless ActiveModel::Serializer.respond_to?(:setup)
       return ActiveModel::Serializer.setup do |config|
         config.adapter == :json_api
       end


### PR DESCRIPTION
Fixes config adapter wrapper so it will be compatible with multiple versions of Active Model Serializer. Tested with 0.9.2 and 0.10.0 versions of AMS

See Issue #644 