### PR TITLE
added bypass_sign_in for next version of Devise

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -61,7 +61,12 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     user = uid && rc.find_by_uid(uid)
 
     if user && user.valid_token?(@token, @client_id)
-      sign_in(:user, user, store: false, bypass: true)
+      # sign_in with bypass: true will be deprecated in the next version of Devise
+      if self.respond_to? :bypass_sign_in
+        bypass_sign_in(user, scope: :user)
+      else
+        sign_in(:user, user, store: false, bypass: true)
+      end
       return @resource = user
     else
       # zero all values previously set values


### PR DESCRIPTION
I'm working off the Devise master branch and getting these annoying deprecation warnings.
<img width="844" alt="1__kendall_kendalls-mbp-2____sites_panacea-api__zsh_" src="https://cloud.githubusercontent.com/assets/1727881/16156775/6493ab38-347b-11e6-8c2e-0b0d59ea38ca.png">

The next version of Devise will deprecate the use of `:bypass` in the `sign_in` method. https://github.com/plataformatec/devise/pull/4078 .

This is a little preemptive, but I've updated devise_token_auth for when the next version of Devise is released. All tests still pass. I didn't know how to test it against Devise's `master` branch but at the very least you can see there's no more deprecation warnings on my tests:

<img width="508" alt="1__kendall_kendalls-mbp-2____sites_panacea-api__zsh_" src="https://cloud.githubusercontent.com/assets/1727881/16156885/cf351e36-347b-11e6-9041-b18f5c9e700b.png">
