### PR TITLE
Fix Migration Deprecation Warning

### DIFF
--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -1,4 +1,4 @@
-class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
+class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration<%= '[' << Rails::VERSION::STRING[0..2] << ']'%>
   def change
     create_table(:<%= user_class.pluralize.underscore %>) do |t|
       ## Required

--- a/test/lib/generators/devise_token_auth/install_generator_test.rb
+++ b/test/lib/generators/devise_token_auth/install_generator_test.rb
@@ -28,6 +28,10 @@ module DeviseTokenAuth
         assert_migration 'db/migrate/devise_token_auth_create_users.rb'
       end
 
+      test 'migration file contains rails version' do
+        assert_migration 'db/migrate/devise_token_auth_create_users.rb', /4.2/
+      end
+
       test 'subsequent runs raise no errors' do
         run_generator
       end


### PR DESCRIPTION
Fix for issue #698 
Update migration template to include version of Rails to silence a Rails 5.0 deprecation warning.

Introduced new logic to in the generator template and added a test to ensure the version number was written to the migration file.

Great to be able to give back 😄 