### PR TITLE
Allow user specific token lifespans

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Models that include the `DeviseTokenAuth::Concerns::User` concern will have acce
   # store client + token in user's token hash
   @resource.tokens[client_id] = {
     token: BCrypt::Password.create(token),
-    expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    expiry: (Time.now + @resource.token_lifespan).to_i
   }
 
   # generate auth headers for response

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -8,7 +8,7 @@ module DeviseTokenAuth
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)
         token_hash = BCrypt::Password.create(token)
-        expiry     = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+        expiry     = (Time.now + @resource.token_lifespan).to_i
 
         @resource.tokens[client_id] = {
           token:  token_hash,

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -162,7 +162,7 @@ module DeviseTokenAuth
       # create token info
       @client_id = SecureRandom.urlsafe_base64(nil, false)
       @token     = SecureRandom.urlsafe_base64(nil, false)
-      @expiry    = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+      @expiry    = (Time.now + @resource.token_lifespan).to_i
       @config    = omniauth_params['config_name']
     end
 

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -80,7 +80,7 @@ module DeviseTokenAuth
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)
         token_hash = BCrypt::Password.create(token)
-        expiry     = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+        expiry     = (Time.now + @resource.token_lifespan).to_i
 
         @resource.tokens[client_id] = {
           token:  token_hash,

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -55,7 +55,7 @@ module DeviseTokenAuth
 
             @resource.tokens[@client_id] = {
               token: BCrypt::Password.create(@token),
-              expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+              expiry: (Time.now + @resource.token_lifespan).to_i
             }
 
             @resource.save!

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -36,7 +36,7 @@ module DeviseTokenAuth
 
         @resource.tokens[@client_id] = {
           token: BCrypt::Password.create(@token),
-          expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+          expiry: (Time.now + @resource.token_lifespan).to_i
         }
         @resource.save
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -164,7 +164,7 @@ module DeviseTokenAuth::Concerns::User
     last_token ||= nil
     token        = SecureRandom.urlsafe_base64(nil, false)
     token_hash   = ::BCrypt::Password.create(token)
-    expiry       = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    expiry       = (Time.now + token_lifespan).to_i
 
     if self.tokens[client_id] and self.tokens[client_id]['token']
       last_token = self.tokens[client_id]['token']
@@ -230,6 +230,9 @@ module DeviseTokenAuth::Concerns::User
     ])
   end
 
+  def token_lifespan
+    DeviseTokenAuth.token_lifespan
+  end
 
   protected
 

--- a/test/dummy/app/controllers/overrides/confirmations_controller.rb
+++ b/test/dummy/app/controllers/overrides/confirmations_controller.rb
@@ -8,7 +8,7 @@ module Overrides
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)
         token_hash = BCrypt::Password.create(token)
-        expiry     = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+        expiry     = (Time.now + @resource.token_lifespan).to_i
 
         @resource.tokens[client_id] = {
           token:  token_hash,

--- a/test/dummy/app/controllers/overrides/passwords_controller.rb
+++ b/test/dummy/app/controllers/overrides/passwords_controller.rb
@@ -12,7 +12,7 @@ module Overrides
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)
         token_hash = BCrypt::Password.create(token)
-        expiry     = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+        expiry     = (Time.now + @resource.token_lifespan).to_i
 
         @resource.tokens[client_id] = {
           token:  token_hash,

--- a/test/dummy/app/controllers/overrides/sessions_controller.rb
+++ b/test/dummy/app/controllers/overrides/sessions_controller.rb
@@ -12,7 +12,7 @@ module Overrides
 
         @resource.tokens[@client_id] = {
           token: BCrypt::Password.create(@token),
-          expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+          expiry: (Time.now + @resource.token_lifespan).to_i
         }
         @resource.save
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,6 +65,40 @@ class UserTest < ActiveSupport::TestCase
         @resource.tokens[@client_id]['expiry'] = Time.now.to_i - 10.seconds
         refute @resource.token_is_current?(@token, @client_id)
       end
+
+    end
+
+    describe 'user specific token lifespan' do
+      before do
+        @resource = users(:confirmed_email_user)
+        @resource.skip_confirmation!
+        @resource.save!
+
+        auth_headers = @resource.create_new_auth_token
+        @token_global     = auth_headers['access-token']
+        @client_id_global = auth_headers['client']
+
+        def @resource.token_lifespan
+          1.minute
+        end
+
+        auth_headers = @resource.create_new_auth_token
+        @token_specific     = auth_headers['access-token']
+        @client_id_specific = auth_headers['client']
+      end
+
+      test 'works per user' do
+        assert @resource.token_is_current?(@token_global, @client_id_global)
+
+        time = Time.now.to_i
+        expiry_global = @resource.tokens[@client_id_global][:expiry]
+        assert expiry_global > time + DeviseTokenAuth.token_lifespan - 5.seconds
+        assert expiry_global < time + DeviseTokenAuth.token_lifespan + 5.seconds
+
+        expiry_specific = @resource.tokens[@client_id_specific][:expiry]
+        assert expiry_specific > time + 55.seconds
+        assert expiry_specific < time + 65.seconds
+      end
     end
 
     describe 'expired tokens are destroyed on save' do


### PR DESCRIPTION
Instead of keeping the token lifespan only in the global configuration, we added a corresponding method in the User Module. This method may be overriden to return a user specific value for the token lifespan. By default, the global value is used.

Use case: We have users working all day with the application in the company headquarters, who do not want to login after short breaks. Other users access the application just for a few minutes from public computers, for whom we prefer to have a very short token lifespan.
