### PR TITLE
Response auth headers if it is batch request

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -113,6 +113,9 @@ module DeviseTokenAuth::Concerns::SetUserByToken
         if @is_batch_request
           auth_header = @resource.extend_batch_buffer(@token, @client_id)
 
+          # update the response header
+          response.headers.merge!(auth_header)
+
         # update Authorization response header with new token
         else
           auth_header = @resource.create_new_auth_token(@client_id)


### PR DESCRIPTION
Fixed logout problem because there is no auth headers for batch request. Issues [#51](https://github.com/lynndylanhurley/devise_token_auth/issues/51), [359](https://github.com/lynndylanhurley/devise_token_auth/issues/359), [541](https://github.com/lynndylanhurley/devise_token_auth/issues/541)