### PR TITLE
Remove params that are not being used in resource params

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -223,7 +223,7 @@ module DeviseTokenAuth
     private
 
     def resource_params
-      params.permit(:email, :password, :password_confirmation, :current_password, :reset_password_token)
+      params.permit(:email, :reset_password_token)
     end
 
     def password_resource_params


### PR DESCRIPTION
#### Why

Just to avoid confusion. When I did some overrides on a project awhile back, it was a little confusing.
#### What

Simply deleted the params not being used in the controller
