### PR TITLE
Update indexes on template

### DIFF
--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -45,7 +45,7 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= user_class.pluralize.underscore %>, :email
+    add_index :<%= user_class.pluralize.underscore %>, :email,                :unique => true
     add_index :<%= user_class.pluralize.underscore %>, [:uid, :provider],     :unique => true
     add_index :<%= user_class.pluralize.underscore %>, :reset_password_token, :unique => true
     # add_index :<%= user_class.pluralize.underscore %>, :confirmation_token,   :unique => true

--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -45,10 +45,10 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= user_class.pluralize.underscore %>, :email,                :unique => true
-    add_index :<%= user_class.pluralize.underscore %>, [:uid, :provider],     :unique => true
-    add_index :<%= user_class.pluralize.underscore %>, :reset_password_token, :unique => true
-    # add_index :<%= user_class.pluralize.underscore %>, :confirmation_token,   :unique => true
-    # add_index :<%= user_class.pluralize.underscore %>, :unlock_token,         :unique => true
+    add_index :<%= user_class.pluralize.underscore %>, :email,                unique: true
+    add_index :<%= user_class.pluralize.underscore %>, [:uid, :provider],     unique: true
+    add_index :<%= user_class.pluralize.underscore %>, :reset_password_token, unique: true
+    # add_index :<%= user_class.pluralize.underscore %>, :confirmation_token, unique: true
+    # add_index :<%= user_class.pluralize.underscore %>, :unlock_token,       unique: true
   end
 end


### PR DESCRIPTION
Why:
Keep data consistent with multiple processes, match devise gem implementation, and latest ruby hash syntax convention.

References:
https://robots.thoughtbot.com/the-perils-of-uniqueness-validations
https://github.com/plataformatec/devise/blob/master/lib/generators/active_record/templates/migration.rb#L13