### PR TITLE
Ruby syntax: replace and/not with &&/!

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -47,7 +47,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     end
 
     # user has already been found and authenticated
-    return @resource if @resource and @resource.class == rc
+    return @resource if @resource && @resource.class == rc
 
     # ensure we clear the client_id
     if !@token
@@ -78,12 +78,12 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
   def update_auth_header
     # cannot save object if model has invalid params
-    return unless @resource and @resource.valid? and @client_id
+    return unless @resource && @resource.valid? && @client_id
 
     # Generate new client_id with existing authentication
     @client_id = nil unless @used_auth_by_token
 
-    if @used_auth_by_token and not DeviseTokenAuth.change_headers_on_each_request
+    if @used_auth_by_token && !DeviseTokenAuth.change_headers_on_each_request
       # should not append auth header if @resource related token was
       # cleared by sign out in the meantime
       return if @resource.reload.tokens[@client_id].nil?

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -142,9 +142,9 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
 
   def is_batch_request?(user, client_id)
-    not params[:unbatch] and
-    user.tokens[client_id] and
-    user.tokens[client_id]['updated_at'] and
+    !params[:unbatch] &&
+    user.tokens[client_id] &&
+    user.tokens[client_id]['updated_at'] &&
     Time.parse(user.tokens[client_id]['updated_at']) > @request_started_at - DeviseTokenAuth.batch_request_buffer_throttle
   end
 end

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -3,7 +3,7 @@ module DeviseTokenAuth
     def show
       @resource = resource_class.confirm_by_token(params[:confirmation_token])
 
-      if @resource and @resource.id
+      if @resource && @resource.id
         # create client id
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -76,7 +76,7 @@ module DeviseTokenAuth
         reset_password_token: resource_params[:reset_password_token]
       })
 
-      if @resource and @resource.id
+      if @resource && @resource.id
         client_id  = SecureRandom.urlsafe_base64(nil, false)
         token      = SecureRandom.urlsafe_base64(nil, false)
         token_hash = BCrypt::Password.create(token)
@@ -119,7 +119,7 @@ module DeviseTokenAuth
       end
 
       # ensure that password params were sent
-      unless password_resource_params[:password] and password_resource_params[:password_confirmation]
+      unless password_resource_params[:password] && password_resource_params[:password_confirmation]
         return render_update_error_missing_password
       end
 

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -186,7 +186,7 @@ module DeviseTokenAuth
     def resource_update_method
       if DeviseTokenAuth.check_current_password_before_update == :attributes
         "update_with_password"
-      elsif DeviseTokenAuth.check_current_password_before_update == :password and account_update_params.has_key?(:password)
+      elsif DeviseTokenAuth.check_current_password_before_update == :password && account_update_params.has_key?(:password)
         "update_with_password"
       elsif account_update_params.has_key?(:current_password)
         "update_with_password"

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -29,7 +29,7 @@ module DeviseTokenAuth
         @resource = resource_class.where(q, q_value).first
       end
 
-      if @resource and valid_params?(field, q_value) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
+      if @resource && valid_params?(field, q_value) && (!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
         valid_password = @resource.valid_password?(resource_params[:password])
         if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
           render_create_error_bad_credentials
@@ -50,7 +50,7 @@ module DeviseTokenAuth
         yield @resource if block_given?
 
         render_create_success
-      elsif @resource and not (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
+      elsif @resource && !(!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
         render_create_error_not_confirmed
       else
         render_create_error_bad_credentials
@@ -63,7 +63,7 @@ module DeviseTokenAuth
       client_id = remove_instance_variable(:@client_id) if @client_id
       remove_instance_variable(:@token) if @token
 
-      if user and client_id and user.tokens[client_id]
+      if user && client_id && user.tokens[client_id]
         user.tokens.delete(client_id)
         user.save!
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -127,10 +127,10 @@ module DeviseTokenAuth::Concerns::User
 
     return true if (
       # ensure that expiry and token are set
-      expiry and token and
+      expiry && token &&
 
       # ensure that the token has not yet expired
-      DateTime.strptime(expiry.to_s, '%s') > Time.now and
+      DateTime.strptime(expiry.to_s, '%s') > Time.now &&
 
       # ensure that the token is valid
       DeviseTokenAuth::Concerns::User.tokens_match?(token_hash, token)
@@ -147,10 +147,10 @@ module DeviseTokenAuth::Concerns::User
 
     return true if (
       # ensure that the last token and its creation time exist
-      updated_at and last_token and
+      updated_at && last_token &&
 
       # ensure that previous token falls within the batch buffer throttle time of the last request
-      Time.parse(updated_at) > Time.now - DeviseTokenAuth.batch_request_buffer_throttle and
+      Time.parse(updated_at) > Time.now - DeviseTokenAuth.batch_request_buffer_throttle &&
 
       # ensure that the token is valid
       ::BCrypt::Password.new(last_token) == token
@@ -166,7 +166,7 @@ module DeviseTokenAuth::Concerns::User
     token_hash   = ::BCrypt::Password.create(token)
     expiry       = (Time.now + DeviseTokenAuth.token_lifespan).to_i
 
-    if self.tokens[client_id] and self.tokens[client_id]['token']
+    if self.tokens[client_id] && self.tokens[client_id]['token']
       last_token = self.tokens[client_id]['token']
     end
 
@@ -189,7 +189,7 @@ module DeviseTokenAuth::Concerns::User
     expiry = self.tokens[client_id]['expiry'] || self.tokens[client_id][:expiry]
 
     max_clients = DeviseTokenAuth.max_number_of_devices
-    while self.tokens.keys.length > 0 and max_clients < self.tokens.keys.length
+    while self.tokens.keys.length > 0 && max_clients < self.tokens.keys.length
       oldest_token = self.tokens.min_by { |cid, v| v[:expiry] || v["expiry"] }
       self.tokens.delete(oldest_token.first)
     end

--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -17,7 +17,7 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
 
   # only validate unique email among users that registered by email
   def unique_email_user
-    if provider == 'email' and self.class.where(provider: 'email', email: email).count > 0
+    if provider == 'email' && self.class.where(provider: 'email', email: email).count > 0
       errors.add(:email, :taken)
     end
   end

--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -57,7 +57,7 @@ module ActionDispatch::Routing
           get "#{full_path}/validate_token", controller: "#{token_validations_ctrl}", action: "validate_token"
 
           # omniauth routes. only define if omniauth is installed and not skipped.
-          if defined?(::OmniAuth) and not opts[:skip].include?(:omniauth_callbacks)
+          if defined?(::OmniAuth) && !opts[:skip].include?(:omniauth_callbacks)
             match "#{full_path}/failure",             controller: omniauth_ctrl, action: "omniauth_failure", via: [:get]
             match "#{full_path}/:provider/callback",  controller: omniauth_ctrl, action: "omniauth_success", via: [:get]
 

--- a/lib/devise_token_auth/url.rb
+++ b/lib/devise_token_auth/url.rb
@@ -4,7 +4,7 @@ module DeviseTokenAuth::Url
     uri = URI(url)
 
     res = "#{uri.scheme}://#{uri.host}"
-    res += ":#{uri.port}" if (uri.port and uri.port != 80 and uri.port != 443)
+    res += ":#{uri.port}" if (uri.port && uri.port != 80 && uri.port != 443)
     res += "#{uri.path}" if uri.path
     query = [uri.query, params.to_query].reject(&:blank?).join('&')
     res += "?#{query}"


### PR DESCRIPTION
This PR changes the tricky English Ruby operators to regular boolean logic operators.

[Read more about the tricky English-and-or at Avdi Grimm's blog](http://www.virtuouscode.com/2010/08/02/using-and-and-or-in-ruby/)

~Update: I can see now that there are many more instances of this, which could be changed, too~

**Update again**: Um, now there seem to be no further instances of this. All changed.
