### PR TITLE
Use standart ActiveRecord error message for email uniqueness validation

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -18,7 +18,7 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
   # only validate unique email among users that registered by email
   def unique_email_user
     if provider == 'email' and self.class.where(provider: 'email', email: email).count > 0
-      errors.add(:email, I18n.t("errors.messages.already_in_use"))
+      errors.add(:email, :taken)
     end
   end
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -28,7 +28,6 @@ de:
       validate_sign_up_params: "Bitte übermitteln sie vollständige Anmeldeinformationen im Body des Requests."
       validate_account_update_params: "Bitte übermitteln sie vollständige Informationen zur Aktualisierung im Body des Requests."
       not_email: "ist keine E-Mail Adresse"
-      already_in_use: "bereits in Verwendung"
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,6 @@ en:
       successfully_updated: "Your password has been successfully updated."
   errors:
     messages:
-      already_in_use: "already in use"
       validate_sign_up_params: "Please submit proper sign up data in request body."
       validate_account_update_params: "Please submit proper account update data in request body."
       not_email: "is not an email"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -28,7 +28,6 @@ es:
       validate_sign_up_params: "Los datos introducidos en la solicitud de acceso no son válidos."
       validate_account_update_params: "Los datos introducidos en la solicitud de actualización no son válidos."
       not_email: "no es un correo electrónico"
-      already_in_use: "ya ha sido ocupado"
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -25,7 +25,6 @@ fr:
       successfully_updated: "Votre mot de passe a été correctement mis à jour."
   errors:
     messages:
-      already_in_use: "déjà utilisé(e)"
       validate_sign_up_params: "Les données d'inscription dans le corps de la requête ne sont pas valides."
       validate_account_update_params: "Les données de mise à jour dans le corps de la requête ne sont pas valides."
       not_email: "n'est pas une adresse e-mail"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,7 +25,6 @@ ja:
       successfully_updated: "パスワードの更新に成功しました。"
   errors:
     messages:
-      already_in_use: "すでに利用されています。"
       validate_sign_up_params: "リクエストボディに適切なアカウント新規登録データを送信してください。"
       validate_account_update_params: "リクエストボディに適切なアカウント更新のデータを送信してください。"
       not_email: "はメールアドレスではありません"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -25,7 +25,6 @@ nl:
       successfully_updated: "Uw wachtwoord is aangepast."
   errors:
     messages:
-      already_in_use: "al in gebruik"
       validate_sign_up_params: "Gegevens voor aanmaken van het account zijn niet geldig."
       validate_account_update_params: "Gegevens voor updaten van het account zijn niet geldig."
       not_email: "is geen geldig e-emailadres"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -27,8 +27,6 @@ pl:
     validate_sign_up_params: "Proszę dostarczyć odpowiednie dane logowania w ciele zapytania."
     validate_account_update_params: "Proszę dostarczyć odpowiednie dane aktualizacji konta w ciele zapytania."
     not_email: "nie jest prawidłowym adresem e-mail"
-    messages:
-      already_in_use: "już w użyciu"
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -25,7 +25,6 @@ pt-BR:
       successfully_updated: "Senha atualizada com sucesso."
   errors:
     messages:
-      already_in_use: "em uso"
       validate_sign_up_params: "Os dados submetidos na requisição de cadastro são inválidos."
       validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
       not_email: "não é um e-mail"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -27,8 +27,6 @@ pt:
     validate_sign_up_params: "Os dados submetidos na requisição de registo são inválidos."
     validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
     not_email: "não é um e-mail"
-    messages:
-      already_in_use: "em uso"
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -25,7 +25,6 @@ ro:
       successfully_updated: "Parola contului a fost schimbată cu succes."
   errors:
     messages:
-      already_in_use: "este deja folosit"
       validate_sign_up_params: "Trimite credențiale valide în body-ul request-ului."
       validate_account_update_params: "Trimite credențiale valide în body-ul request-ului."
       not_email: "nu este un email"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -24,11 +24,10 @@ ru:
       missing_passwords: "Вы должны заполнить поля 'пароль' и 'повторите пароль'."
       successfully_updated: "Ваш пароль успешно обновлён."
   errors:
-    validate_sign_up_params: "Пожалуйста, укажите надлежащие данные для регистрации в теле запроса."
-    validate_account_update_params: "Пожалуйста, укажите надлежащие данные для обновления учетной записи в теле запроса."
-    not_email: "не является электронной почтой"
     messages:
-      already_in_use: "уже используется"
+      validate_sign_up_params: "Пожалуйста, укажите надлежащие данные для регистрации в теле запроса."
+      validate_account_update_params: "Пожалуйста, укажите надлежащие данные для обновления учетной записи в теле запроса."
+      not_email: "не является электронной почтой"
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -25,7 +25,6 @@ zh-CN:
       successfully_updated: "您的密码已被修改。"
   errors:
     messages:
-      already_in_use: "已被使用。"
       validate_sign_up_params: "请在request body中填入有效的注册内容"
       validate_account_update_params: "请在request body中填入有效的更新帐号资料"
       not_email: "这不是一个合适的邮箱。"
@@ -43,12 +42,5 @@ zh-CN:
         account_lock_msg: "由于多次登入失败，我们已锁定你的帐号"
         unlock_link_msg: "可以使用下面的链接解锁你的帐号"
         unlock_link: "解锁帐号"
-  activerecord:
-    errors:
-      models:
-        user:
-          attributes:
-            email:
-              already_in_use: "邮箱已被使用"
   hello: "你好"
   welcome: "欢迎"

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -27,7 +27,6 @@ zh-TW:
       successfully_updated: "您的密碼已被修改。"
   errors:
     messages:
-      already_in_use: "已被使用。"
       validate_sign_up_params: "請在request body中填入有效的註冊內容"
       validate_account_update_params: "請在request body中填入有效的更新帳號資料"
       not_email: "這不是一個合適的電郵。"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -27,7 +27,6 @@ zh-TW:
       successfully_updated: "您的密碼已被修改。"
   errors:
     messages:
-      already_in_use: "已被使用。"
       validate_sign_up_params: "請在request body中填入有效的註冊內容"
       validate_account_update_params: "請在request body中填入有效的更新帳號資料"
       not_email: "這不是一個合適的電郵。"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -35,6 +35,28 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'email uniqueness' do
+      test 'model should not save if email is taken' do
+        provider = 'email'
+
+        User.create(
+          email: @email,
+          provider: provider,
+          password: @password,
+          password_confirmation: @password
+        )
+
+        @resource.email                 = @email
+        @resource.provider              = provider
+        @resource.password              = @password
+        @resource.password_confirmation = @password
+
+        refute @resource.save
+        assert @resource.errors.messages[:email] == [I18n.t('errors.messages.taken')]
+        assert @resource.errors.messages[:email].none? { |e| e =~ /translation missing/ }
+      end
+    end
+
     describe 'oauth2 authentication' do
       test 'model should save even if email is blank' do
         @resource.provider              = 'facebook'


### PR DESCRIPTION
According to the [Rails Guides](http://guides.rubyonrails.org/v5.0/i18n.html#error-message-interpolation) there already is a localization for the uniqueness validation. And the key is `:taken`.

So if one wants to provide his own translation, he should redefine one of the keys in the following order:

```
activerecord.errors.models.user.attributes.email.taken
activerecord.errors.models.user.taken
activerecord.errors.messages.taken
errors.attributes.email.taken
errors.messages.taken
```