### PR TITLE
change auth_token to access-token and client_id to client in params 

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -168,8 +168,8 @@ module DeviseTokenAuth
 
     def create_auth_params
       @auth_params = {
-        auth_token:     @token,
-        client_id: @client_id,
+        "access-token" => @token,
+        client:    @client_id,
         uid:       @resource.uid,
         expiry:    @expiry,
         config:    @config

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -45,8 +45,8 @@ class OmniauthTest < ActionDispatch::IntegrationTest
 
     test 'user should be assigned token' do
       get_success
-      client_id = controller.auth_params[:client_id]
-      token = controller.auth_params[:auth_token]
+      client_id = controller.auth_params[:client]
+      token = controller.auth_params["access-token"]
       expiry = controller.auth_params[:expiry]
 
       # the expiry should have been set
@@ -226,7 +226,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
         assert(uid = controller.params['uid'], "No uid found")
 
         # check that all the auth stuff is there
-        [:auth_token, :client_id, :uid, :expiry, :config].each do |key|
+        ["access-token", :client, :uid, :expiry, :config].each do |key|
           assert(controller.params.key?(key), "No value for #{key.inspect}")
         end
       end
@@ -322,7 +322,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
     end
 
     test 'should support wildcards' do
-      DeviseTokenAuth.redirect_whitelist = ["#{@good_redirect_url[0..8]}*"]
+     DeviseTokenAuth.redirect_whitelist = ["#{@good_redirect_url[0..8]}*"]
       get_via_redirect '/auth/facebook',
                        auth_origin_url: @good_redirect_url,
                        omniauth_window_type: 'newWindow'


### PR DESCRIPTION
I think these parameter names needs to be changed. After this change the application was able display omniauth params after redirect.