### PR TITLE
Fixes constructing redirect_route

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -13,7 +13,8 @@ module DeviseTokenAuth
       # before authentication.
       devise_mapping = [request.env['omniauth.params']['namespace_name'],
                         request.env['omniauth.params']['resource_class'].underscore.gsub('/', '_')].compact.join('_')
-      redirect_route = "#{request.protocol}#{request.host_with_port}/#{Devise.mappings[devise_mapping.to_sym].fullpath}/#{params[:provider]}/callback"
+      path = "#{Devise.mappings[devise_mapping.to_sym].fullpath}/#{params[:provider]}/callback"
+      redirect_route = URI::HTTP.build(scheme: request.scheme, host: request.host, port: request.port, path: path).to_s
 
       # preserve omniauth info for success route. ignore 'extra' in twitter
       # auth response to avoid CookieOverflow.

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -66,6 +66,11 @@ class OmniauthTest < ActionDispatch::IntegrationTest
       get_success
     end
 
+    test 'should be redirected via valid url' do
+      get_success
+      assert_equal 'http://www.example.com/auth/facebook/callback', request.original_url
+    end
+
     describe 'with default user model' do
       before do
         get_success


### PR DESCRIPTION
Fixes double slash in redirection url issue reported in https://github.com/lynndylanhurley/devise_token_auth/issues/749 .

The PR solves the issue but it's not critical at all - turns out redirection works fine even with the double slash. You can see it on [my example app](http://ng2auth-router-starter.netlify.com/).

Anyway, it would be nice to merge this to prevent potential future issues.