### PR TITLE
Travis: use the code_climate addon config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ rvm:
   - 2.3.1
 
 env:
-  - DB=sqlite
-  - DB=mysql
-  - DB=postgresql
+  global:
+    - RAILS_ENV=test
+  matrix:
+    - DB=sqlite
+    - DB=mysql
+    - DB=postgresql
 
 script:
-  - RAILS_ENV=test bundle exec rake --trace db:migrate
-  - RAILS_ENV=test CODECLIMATE_REPO_TOKEN=44d7688de8e1b567b4af25ec5083c2cc0a355ab911192a7cbefd1ea25b2ffd3d bundle exec rake
+  - bundle exec rake --trace db:migrate
+  - bundle exec rake
 
 before_script:
   - mysql -e 'create database devise_token_auth_test'
@@ -20,3 +23,8 @@ before_script:
 
 addons:
   postgresql: "9.4"
+  code_climate:
+    - repo_token: 44d7688de8e1b567b4af25ec5083c2cc0a355ab911192a7cbefd1ea25b2ffd3d
+
+after_success:
+  - bundle exec codeclimate-test-reporter


### PR DESCRIPTION
This PR modifies the Travis config file to:

- configure Code Climate with the `addon` for [Code Climate (docs)](https://docs.codeclimate.com/v1.0/docs/travis-ci-ruby-test-coverage).
- have shared ENV vars in the `global` section