### PR TITLE
Don't send extra data on request password reset

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -168,7 +168,6 @@ module DeviseTokenAuth
     def render_create_success
       render json: {
         success: true,
-        data: resource_data,
         message: I18n.t("devise_token_auth.passwords.sended", email: @email)
       }
     end

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -73,6 +73,21 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
           end
         end
 
+        describe 'successfully requested password reset' do
+          before do
+            xhr :post, :create, {
+              email:        @resource.email,
+              redirect_url: @redirect_url
+            }
+
+            @data = JSON.parse(response.body)
+          end
+
+            test 'response should not contain extra data' do
+              assert_equal @data['data'], nil
+            end
+        end
+
 
         describe 'case-sensitive email' do
           before do


### PR DESCRIPTION
Why:

* This resolves Issues #797 
* So we don't leak any user data

This change addresses the need by:

* Not returning extra data after request
* Spec