### PR TITLE
Fix privacy issue with password reset request

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -168,7 +168,6 @@ module DeviseTokenAuth
     def render_create_success
       render json: {
         success: true,
-        data: resource_data,
         message: I18n.t("devise_token_auth.passwords.sended", email: @email)
       }
     end


### PR DESCRIPTION
Returning `resource_data` in `render_create_success` allows anyone to get all user data that is being serialized in application from resource model by using just an email, as

`POST /api/v1/auth/password` with `{email: 'buddy.lebsack@example.net', return_url: '...'}`

returns body like that:

```
{
  "success": true,
  "data": {
    "id": 130,
    "uid": "buddy.lebsack@example.net",
    "unconfirmed_email": null,
    "email": "buddy.lebsack@example.net",
    "first_name": "Kiana",
    "last_name": "Kiehn",
    "organization": "Vel",
    "phone": "551-432-2662",
    ...
  },
  "message": "..."
}
```

I think that this is a regression that was introduced in [this commit](https://github.com/lynndylanhurley/devise_token_auth/commit/4f7fdf789f51c9499582d264811e211fe5ad170b)

This pr removes that data from response.