### PR TITLE
Prevent getting table info if not connected to db

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -95,7 +95,15 @@ module DeviseTokenAuth::Concerns::User
 
 
     def tokens_has_json_column_type?
-      table_exists? && self.columns_hash['tokens'] && self.columns_hash['tokens'].type.in?([:json, :jsonb])
+      database_exists? && table_exists? && self.columns_hash['tokens'] && self.columns_hash['tokens'].type.in?([:json, :jsonb])
+    end
+
+    def database_exists?
+      ActiveRecord::Base.connection
+    rescue ActiveRecord::NoDatabaseError
+      false
+    else
+      true
     end
   end
 


### PR DESCRIPTION
Fixes #327

When precompiling assets while building a docker image, the database is not
available and the DeviseTokenAuth::Concerns::User concern tries to load
user table information from database and fails. It now checks if the
database connection is established before gathering information about user
table.