### PR TITLE
GitHub Issues template, Contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+1. Create a feature branch with your changes.
+2. Write some test cases.
+3. Make all the tests pass.
+4. Issue a pull request.
+
+I will grant you commit access if you send quality pull requests.
+
+To run the test suite do the following:
+
+1. Clone this repo
+2. Run `bundle install`
+3. Run `rake db:migrate`
+4. Run `RAILS_ENV=test rake db:migrate`
+5. Run `guard`
+
+The last command will open the [guard](https://github.com/guard/guard) test-runner. Guard will re-run each test suite when changes are made to its corresponding files.
+
+To run just one test:
+
+1. Clone this repo
+2. Run `bundle install`
+3. Run `rake db:migrate`
+4. Run `RAILS_ENV=test rake db:migrate`
+5. See this link for various ways to run a single file or a single test: http://flavio.castelli.name/2010/05/28/rails_execute_single_test/
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+When posting issues, please include the following information to speed up the troubleshooting process:
+
+* **Version**: which version of this gem (and [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth), [jToker](https://github.com/lynndylanhurley/j-toker) or [Angular2-Token](https://github.com/neroniaky/angular2-token) if applicable) are you using?
+* **Request and response headers**: these can be found in the "Network" tab of your browser's web inspector.
+* **Rails Stacktrace**: this can be found in the `log/development.log` of your API.
+* **Environmental Info**: How is your application different from the [reference implementation](https://github.com/lynndylanhurley/devise_token_auth_demo)? This may include (but is not limited to) the following details:
+  * **Routes**: are you using some crazy namespace, scope, or constraint?
+  * **Gems**: are you using MongoDB, Grape, RailsApi, ActiveAdmin, etc.?
+  * **Custom Overrides**: what have you done in terms of [custom controller overrides](https://github.com/lynndylanhurley/devise_token_auth/#custom-controller-overrides)?
+  * **Custom Frontend**: are you using [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth), [jToker](https://github.com/lynndylanhurley/j-toker), [Angular2-Token](https://github.com/neroniaky/angular2-token), or something else?

--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ These files may be edited to suit your taste. You can customize the e-mail subje
 
 When posting issues, please include the information mentioned in the [ISSUE_TEMPLATE.md].
 
-[ISSUE_TEMPLATE.md]: ./.github/ISSUE_TEMPLATE.md
+[ISSUE_TEMPLATE.md]: https://github.com/lynndylanhurley/devise_token_auth/blob/master/.github/ISSUE_TEMPLATE.md
 
 # FAQ
 
@@ -913,7 +913,7 @@ Thanks to the following contributors:
 
 See the [CONTRIBUTING.md] document.
 
-[CONTRIBUTING.md]: ./.github/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/lynndylanhurley/devise_token_auth/blob/master/.github/CONTRIBUTING.md
 
 # License
 This project uses the WTFPL

--- a/README.md
+++ b/README.md
@@ -768,16 +768,9 @@ These files may be edited to suit your taste. You can customize the e-mail subje
 
 # Issue Reporting
 
-When posting issues, please include the following information to speed up the troubleshooting process:
+When posting issues, please include the information mentioned in the [ISSUE_TEMPLATE.md].
 
-* **Version**: which version of this gem (and [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth), [jToker](https://github.com/lynndylanhurley/j-toker) or [Angular2-Token](https://github.com/neroniaky/angular2-token) if applicable) are you using?
-* **Request and response headers**: these can be found in the "Network" tab of your browser's web inspector.
-* **Rails Stacktrace**: this can be found in the `log/development.log` of your API.
-* **Environmental Info**: How is your application different from the [reference implementation](https://github.com/lynndylanhurley/devise_token_auth_demo)? This may include (but is not limited to) the following details:
-  * **Routes**: are you using some crazy namespace, scope, or constraint?
-  * **Gems**: are you using MongoDB, Grape, RailsApi, ActiveAdmin, etc.?
-  * **Custom Overrides**: what have you done in terms of [custom controller overrides](#custom-controller-overrides)?
-  * **Custom Frontend**: are you using [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth), [jToker](https://github.com/lynndylanhurley/j-toker), [Angular2-Token](https://github.com/neroniaky/angular2-token), or something else?
+[ISSUE_TEMPLATE.md]: ./.github/ISSUE_TEMPLATE.md
 
 # FAQ
 
@@ -918,30 +911,9 @@ Thanks to the following contributors:
 
 # Contributing
 
-1. Create a feature branch with your changes.
-2. Write some test cases.
-3. Make all the tests pass.
-4. Issue a pull request.
+See the [CONTRIBUTING.md] document.
 
-I will grant you commit access if you send quality pull requests.
-
-To run the test suite do the following:
-
-1. Clone this repo
-2. Run `bundle install`
-3. Run `rake db:migrate`
-4. Run `RAILS_ENV=test rake db:migrate`
-5. Run `guard`
-
-The last command will open the [guard](https://github.com/guard/guard) test-runner. Guard will re-run each test suite when changes are made to its corresponding files.
-
-To run just one test:
-
-1. Clone this repo
-2. Run `bundle install`
-3. Run `rake db:migrate`
-4. Run `RAILS_ENV=test rake db:migrate`
-5. See this link for various ways to run a single file or a single test: http://flavio.castelli.name/2010/05/28/rails_execute_single_test/
+[CONTRIBUTING.md]: ./.github/CONTRIBUTING.md
 
 # License
 This project uses the WTFPL


### PR DESCRIPTION
This repository gets quite a few reports that are questions, or reports about issues which do not have enough detail to be answered effienctly.

This PR adds a .github folder with [an Issue Template and the Contributing](https://github.com/blog/2111-issue-and-pull-request-templates) section of the README as separate files.

The README now links to these files.

- [ ] Consider if the guideline documents need rewording, headings or the like
- [ ] Consider if the files ought to go in the root folder
- [x] Consider if the README ought to link to the files instead of repeating content