### PR TITLE
Ability to use different default fields in model

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -78,12 +78,8 @@ module DeviseTokenAuth
 
     # break out provider attribute assignment for easy method extension
     def assign_provider_attrs(user, auth_hash)
-      user.assign_attributes({
-        nickname: auth_hash['info']['nickname'],
-        name:     auth_hash['info']['name'],
-        image:    auth_hash['info']['image'],
-        email:    auth_hash['info']['email']
-      })
+      attrs = auth_hash['info'].slice(*user.attributes.keys)
+      user.assign_attributes(attrs)
     end
 
     # derive allowed params from the standard devise parameter sanitizer


### PR DESCRIPTION
Now you do not need to use required nickname, image and name fields