### PR TITLE
Added transaction protection to action of create session

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -12,48 +12,50 @@ module DeviseTokenAuth
       # Check
       field = (resource_params.keys.map(&:to_sym) & resource_class.authentication_keys).first
 
-      @resource = nil
-      if field
-        q_value = resource_params[field]
+      resource_class.transaction do
+        @resource = nil
+        if field
+          q_value = resource_params[field]
 
-        if resource_class.case_insensitive_keys.include?(field)
-          q_value.downcase!
+          if resource_class.case_insensitive_keys.include?(field)
+            q_value.downcase!
+          end
+
+          q = "#{field.to_s} = ? AND provider='email'"
+
+          if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+            q = "BINARY " + q
+          end
+
+          @resource = resource_class.where(q, q_value).lock.first
         end
 
-        q = "#{field.to_s} = ? AND provider='email'"
+        if @resource && valid_params?(field, q_value) && (!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
+          valid_password = @resource.valid_password?(resource_params[:password])
+          if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
+            render_create_error_bad_credentials
+            return
+          end
+          # create client id
+          @client_id = SecureRandom.urlsafe_base64(nil, false)
+          @token     = SecureRandom.urlsafe_base64(nil, false)
 
-        if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-          q = "BINARY " + q
-        end
+          @resource.tokens[@client_id] = {
+            token: BCrypt::Password.create(@token),
+            expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+          }
+          @resource.save
 
-        @resource = resource_class.where(q, q_value).first
-      end
+          sign_in(:user, @resource, store: false, bypass: false)
 
-      if @resource && valid_params?(field, q_value) && (!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
-        valid_password = @resource.valid_password?(resource_params[:password])
-        if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
+          yield @resource if block_given?
+
+          render_create_success
+        elsif @resource && !(!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
+          render_create_error_not_confirmed
+        else
           render_create_error_bad_credentials
-          return
         end
-        # create client id
-        @client_id = SecureRandom.urlsafe_base64(nil, false)
-        @token     = SecureRandom.urlsafe_base64(nil, false)
-
-        @resource.tokens[@client_id] = {
-          token: BCrypt::Password.create(@token),
-          expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
-        }
-        @resource.save
-
-        sign_in(:user, @resource, store: false, bypass: false)
-
-        yield @resource if block_given?
-
-        render_create_success
-      elsif @resource && !(!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
-        render_create_error_not_confirmed
-      else
-        render_create_error_bad_credentials
       end
     end
 


### PR DESCRIPTION
I've found a multithreading problem in devise_token_auth library.

When 2 or more requests to create a new session are sending in the same time for a single user, there is a big chance to get a collision. It looks strange, because both responses will have a token keys, but only the last one will be valid.

The problem is, that tokens are stored in one row of the table. Both of synchronous requests can rewrite tokens of each other. 

_How it worked before this fix._
Firstly we get a row from a user table, then we generate a new token and add it to a field of user's model. Than we update a user's row in database.  But, someone else can send the same response, while we are changing and saving the updated user row. As result, only one token will be saved and valid as well.

**Solution**
It's simple, just wrap both of SQL requests `SELECT` and `UPDATE` in a single transaction.

**Testing**
Currently all tests are passed successful. Unfortunately I can't to write a new test for this fix, because sqlite doesn't support transaction mechanism as well. 

I tried to use this code in the before block:
```ruby
        before do
          @respones = 2.times.to_a.map do
            Thread.new do
              xhr :post, :create, { email: @existing_user.email, password: 'secret123' }
            end
          end.each(&:join)
        end
```

But got the same errors every time: "ActiveRecord::StatementInvalid: SQLite3::BusyException: database is locked: ... "

Anyway, I've tested this fix in real project with real heavy loading requests in MySQL and PostgreeSQL databases. The fix works pretty good, in more than 10 synchronous requests. Before the fix I've got a lot of invalid authorisations responses with only 2 synchronous requests.