### PR TITLE
Rename find_by methods

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -58,7 +58,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     return false unless @token
 
     # mitigate timing attacks by finding by uid instead of auth token
-    user = uid && rc.find_by_uid(uid)
+    user = uid && rc.find_by(uid: uid)
 
     if user && user.valid_token?(@token, @client_id)
       # sign_in with bypass: true will be deprecated in the next version of Devise

--- a/test/dummy/app/controllers/overrides/sessions_controller.rb
+++ b/test/dummy/app/controllers/overrides/sessions_controller.rb
@@ -3,7 +3,7 @@ module Overrides
     OVERRIDE_PROOF = "(^^,)"
 
     def create
-      @resource = resource_class.find_by_email(resource_params[:email])
+      @resource = resource_class.find_by(email: resource_params[:email])
 
       if @resource and valid_params?(:email, resource_params[:email]) and @resource.valid_password?(resource_params[:password]) and @resource.confirmed?
         # create client id


### PR DESCRIPTION
Hello,

In Rails5, `find_by` methods remplace all `find_by_#{attr}` methods.

So I change them to be conform with the new rules :)

Thank for review ! 