### PR TITLE
Persist allow_password_change in the database

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -125,6 +125,7 @@ module DeviseTokenAuth
 
       if @resource.send(resource_update_method, password_resource_params)
         @resource.allow_password_change = false
+        @resource.save!
 
         yield @resource if block_given?
         return render_update_success

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -41,12 +41,6 @@ module DeviseTokenAuth::Concerns::User
     # remove old tokens if password has changed
     before_save :remove_tokens_after_password_reset
 
-    # allows user to change password without current_password
-    attr_writer :allow_password_change
-    def allow_password_change
-      @allow_password_change || false
-    end
-
     # don't use default devise email validation
     def email_required?
       false

--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -11,6 +11,7 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -332,6 +332,9 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
               redirect_url: @mail_redirect_url
             }
 
+            @resource.reload
+            @allow_password_change_after_reset = @resource.allow_password_change
+
             @auth_headers = @resource.create_new_auth_token
             request.headers.merge!(@auth_headers)
             @new_password = Faker::Internet.password
@@ -342,12 +345,17 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
             }
 
             @data = JSON.parse(response.body)
+            @resource.reload
             @allow_password_change = @resource.allow_password_change
             @resource.reload
           end
 
           test "request should be successful" do
             assert_equal 200, response.status
+          end
+
+          test "changes allow_password_change to true on reset" do
+            assert_equal true, @allow_password_change_after_reset
           end
 
           test "sets allow_password_change false" do

--- a/test/dummy/db/migrate/20140715061447_devise_token_auth_create_users.rb
+++ b/test/dummy/db/migrate/20140715061447_devise_token_auth_create_users.rb
@@ -11,6 +11,7 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
       t.string   :reset_password_redirect_url
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20140715061805_devise_token_auth_create_mangs.rb
+++ b/test/dummy/db/migrate/20140715061805_devise_token_auth_create_mangs.rb
@@ -11,6 +11,7 @@ class DeviseTokenAuthCreateMangs < ActiveRecord::Migration
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
       t.string   :reset_password_redirect_url
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20140928231203_devise_token_auth_create_evil_users.rb
+++ b/test/dummy/db/migrate/20140928231203_devise_token_auth_create_evil_users.rb
@@ -10,6 +10,7 @@ class DeviseTokenAuthCreateEvilUsers < ActiveRecord::Migration
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20141222053502_devise_token_auth_create_unregisterable_users.rb
+++ b/test/dummy/db/migrate/20141222053502_devise_token_auth_create_unregisterable_users.rb
@@ -13,6 +13,7 @@ class DeviseTokenAuthCreateUnregisterableUsers < ActiveRecord::Migration
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
+++ b/test/dummy/db/migrate/20150409095712_devise_token_auth_create_nice_users.rb
@@ -13,6 +13,7 @@ class DeviseTokenAuthCreateNiceUsers < ActiveRecord::Migration
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
+++ b/test/dummy/db/migrate/20150708104536_devise_token_auth_create_unconfirmable_users.rb
@@ -13,6 +13,7 @@ class DeviseTokenAuthCreateUnconfirmableUsers < ActiveRecord::Migration
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20160103235141_devise_token_auth_create_scoped_users.rb
+++ b/test/dummy/db/migrate/20160103235141_devise_token_auth_create_scoped_users.rb
@@ -13,6 +13,7 @@ class DeviseTokenAuthCreateScopedUsers < ActiveRecord::Migration
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       t.datetime :remember_created_at

--- a/test/dummy/db/migrate/20160629184441_devise_token_auth_create_lockable_users.rb
+++ b/test/dummy/db/migrate/20160629184441_devise_token_auth_create_lockable_users.rb
@@ -13,6 +13,7 @@ class DeviseTokenAuthCreateLockableUsers < ActiveRecord::Migration
       ## Recoverable
       # t.string   :reset_password_token
       # t.datetime :reset_password_sent_at
+      # t.boolean  :allow_password_change, :default => false
 
       ## Rememberable
       # t.datetime :remember_created_at

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.string   "reset_password_redirect_url"
+    t.boolean  "allow_password_change",       default: false
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",               default: 0,  null: false
     t.datetime "current_sign_in_at"
@@ -103,6 +104,7 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
+    t.boolean  "allow_password_change",  default: false
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
@@ -148,6 +150,7 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
+    t.boolean  "allow_password_change",  default: false
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
@@ -177,6 +180,7 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
+    t.boolean  "allow_password_change",  default: false
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
@@ -202,6 +206,7 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
+    t.boolean  "allow_password_change",  default: false
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
@@ -231,6 +236,7 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.string   "reset_password_redirect_url"
+    t.boolean  "allow_password_change",       default: false
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",               default: 0,  null: false
     t.datetime "current_sign_in_at"


### PR DESCRIPTION
Fixes #481 
`@resource.allow_password_change` is not persisted across requests which makes it impossible to reset a user's password after a password reset when `config.check_current_password_before_update` is set to `:password`.
This pull request:
1- Modifies the generators to add the new column.
2- Adds a new test to cover this case.
3- Removes the old attribute accessors.