### PR TITLE
use URI::HTTPS to generate HTTPS redirects

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -14,7 +14,8 @@ module DeviseTokenAuth
       devise_mapping = [request.env['omniauth.params']['namespace_name'],
                         request.env['omniauth.params']['resource_class'].underscore.gsub('/', '_')].compact.join('_')
       path = "#{Devise.mappings[devise_mapping.to_sym].fullpath}/#{params[:provider]}/callback"
-      redirect_route = URI::HTTP.build(scheme: request.scheme, host: request.host, port: request.port, path: path).to_s
+      klass = request.scheme == 'https' ? URI::HTTPS : URI::HTTP
+      redirect_route = klass.build(host: request.host, port: request.port, path: path).to_s
 
       # preserve omniauth info for success route. ignore 'extra' in twitter
       # auth response to avoid CookieOverflow.


### PR DESCRIPTION
When deploying my app, I noticed the callback URL (after this redirect) was stalling, trying to load `http://my-app.herokuapp.com:443/api/auth/twitter/callback`. Playing with `URI::HTTP.build` and `URI::HTTPS.build`, I noticed the `scheme` kwarg is ignored
```ruby
> URI::HTTP.build(scheme: 'http', host: 'hi.com', port: 80).to_s
=> "http://hi.com"
> URI::HTTP.build(scheme: 'https', host: 'hi.com', port: 443).to_s
=> "http://hi.com:443"
> URI::HTTPS.build(scheme: 'http', host: 'hi.com', port: 80).to_s
=> "https://hi.com:80"
> URI::HTTPS.build(scheme: 'https', host: 'hi.com', port: 443).to_s
=> "https://hi.com"
```

It seems like the best solution is to switch which `build()` we are using based on the request scheme. I modeled my change after this PR https://github.com/fog/fog/pull/2159 which seems to be the same issue. I was unable to write a test because I don't think `request_via_redirect` or `get_via_redirect` supports having a scheme like `https`.