### PR TITLE
client_id missing in extend_batch_buffer method

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -194,7 +194,7 @@ module DeviseTokenAuth::Concerns::User
 
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
-    expiry = self.tokens[client_id]['expiry'] || self.tokens[client_id][:expiry]
+    expiry = self.tokens[client_id]['expiry'] || self.tokens[client_id][:expiry] ||  (Time.now + DeviseTokenAuth.token_lifespan).to_i
 
     max_clients = DeviseTokenAuth.max_number_of_devices
     while self.tokens.keys.length > 0 && max_clients < self.tokens.keys.length

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -223,7 +223,9 @@ module DeviseTokenAuth::Concerns::User
 
 
   def extend_batch_buffer(token, client_id)
-    self.tokens[client_id]['updated_at'] = Time.now
+    if self.tokens[client_id] != nil
+      self.tokens[client_id]['updated_at'] = Time.now
+    end
 
     return build_auth_header(token, client_id)
   end

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -194,7 +194,7 @@ module DeviseTokenAuth::Concerns::User
 
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
-    expiry = self.tokens[client_id]['expiry'] || self.tokens[client_id][:expiry] ||  (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    expiry = (Time.now + DeviseTokenAuth.token_lifespan).to_i
 
     max_clients = DeviseTokenAuth.max_number_of_devices
     while self.tokens.keys.length > 0 && max_clients < self.tokens.keys.length


### PR DESCRIPTION
This is causing the error undefined method `[]=' for nil:NilClass because tokens[client_id] is missing. The client_id here needs to be present to update the token with the new time.

```
  def extend_batch_buffer(token, client_id)
      self.tokens[client_id]['updated_at'] = Time.now

    return build_auth_header(token, client_id)
  end
```
So the error `undefined method `[]=' for nil:NilClass` is because of client_id missing and the method cannot update the time of with updated_at column.
