### PR TITLE
Support setting whitelist, without setting default redirect_url

### DIFF
--- a/lib/devise_token_auth/url.rb
+++ b/lib/devise_token_auth/url.rb
@@ -14,7 +14,7 @@ module DeviseTokenAuth::Url
   end
 
   def self.whitelisted?(url)
-    !!DeviseTokenAuth.redirect_whitelist.find { |pattern| !!Wildcat.new(pattern).match(url) }
+    url.nil? || !!DeviseTokenAuth.redirect_whitelist.find { |pattern| !!Wildcat.new(pattern).match(url) }
   end
 
 


### PR DESCRIPTION
### Error:

`Redirect to '' not allowed`

### Steps to reproduce

1. set `redirect_whitelist` (to `['google.com']`, for example)
2. _don't_ set `default_confirm_success_url`
3. Try and create a new user via `POST /`

### Expected outcome

A successful registration

### Actual outcome

You should get `Redirect to '' not allowed`

### This change resolves the issue.