### PR TITLE
bypass_sign_in setting (re-created)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The following settings are available for configuration in `config/initializers/d
 | **`enable_standard_devise_support`** | `false` | By default, only Bearer Token authentication is implemented out of the box. If, however, you wish to integrate with legacy Devise authentication, you can do so by enabling this flag. NOTE: This feature is highly experimental! |
 | **`remove_tokens_after_password_reset`** | `false` | By default, old tokens are not invalidated when password is changed. Enable this option if you want to make passwords updates to logout other devices. |
 | **`default_callbacks`** | `true` | By default User model will include the `DeviseTokenAuth::Concerns::UserOmniauthCallbacks` concern, which has `email`, `uid` validations & `uid` synchronization callbacks. |
+| **`bypass_sign_in`** | `true` | By default DeviseTokenAuth will not check user's `#active_for_authentication?` which includes confirmation check on each call (it will do it only on sign in). If you want it to be validated on each request (for example, to be able to deactivate logged in users on the fly), set it to false. |
 
 
 Additionally, you can configure other aspects of devise by manually creating the traditional devise.rb file at `config/initializers/devise.rb`. Here are some examples of what you can do in this file:

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -62,10 +62,10 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     if user && user.valid_token?(@token, @client_id)
       # sign_in with bypass: true will be deprecated in the next version of Devise
-      if self.respond_to? :bypass_sign_in
+      if self.respond_to?(:bypass_sign_in) && DeviseTokenAuth.bypass_sign_in
         bypass_sign_in(user, scope: :user)
       else
-        sign_in(:user, user, store: false, bypass: true)
+        sign_in(:user, user, store: false, event: :fetch, bypass: DeviseTokenAuth.bypass_sign_in)
       end
       return @resource = user
     else

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -21,7 +21,8 @@ module DeviseTokenAuth
                  :enable_standard_devise_support,
                  :remove_tokens_after_password_reset,
                  :default_callbacks,
-                 :headers_names
+                 :headers_names,
+                 :bypass_sign_in
 
   self.change_headers_on_each_request       = true
   self.max_number_of_devices                = 10
@@ -40,6 +41,7 @@ module DeviseTokenAuth
                                                :'expiry' => 'expiry',
                                                :'uid' => 'uid',
                                                :'token-type' => 'token-type' }
+  self.bypass_sign_in                       = true
 
   def self.setup(&block)
     yield self

--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -378,6 +378,62 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    describe 'bypass_sign_in' do
+      before do
+        @resource = users(:unconfirmed_email_user)
+        @resource.save!
+
+        @auth_headers = @resource.create_new_auth_token
+
+        @token     = @auth_headers['access-token']
+        @client_id = @auth_headers['client']
+        @expiry    = @auth_headers['expiry']
+      end
+      describe 'is default value (true)' do
+        before do
+          age_token(@resource, @client_id)
+
+          get '/demo/members_only', {}, @auth_headers
+
+          @access_token = response.headers['access-token']
+          @response_status = response.status
+        end
+
+        it 'should allow the request through' do
+          assert_equal 200, @response_status
+        end
+
+        it 'should return auth headers' do
+          assert @access_token
+        end
+
+        it 'should set current user' do
+          assert_equal @controller.current_user, @resource
+        end
+      end
+      describe 'is false' do
+        before do
+          DeviseTokenAuth.bypass_sign_in = false
+          age_token(@resource, @client_id)
+
+          get '/demo/members_only', {}, @auth_headers
+
+          @access_token = response.headers['access-token']
+          @response_status = response.status
+
+          DeviseTokenAuth.bypass_sign_in = true
+        end
+
+        it 'should not allow the request through' do
+          refute_equal 200, @response_status
+        end
+
+        it 'should not return auth headers from the first request' do
+          assert_nil @access_token
+        end
+      end
+    end
+
     describe 'enable_standard_devise_support' do
 
       before do


### PR DESCRIPTION
This PR adds a configuration to force passing warden fetch hooks on each call which includes access token. 

This may be useful, for example, for `activatable` [hook implementation](https://github.com/plataformatec/devise/blob/master/lib/devise/hooks/activatable.rb) (you add `active` column to users table, and set it to `true` when you want to allow people to log in, but set this to `false` when you want to block them).

Default behavior remains the same.

When `DeviseTokenAuth.bypass_sign_in` is set to `false`, users which return `false` to `active_for_authentication?` will be locked immediately, and won't be able to run any actions using their access token, even if it was valid before their inactivation.

We use `event: :fetch`, because we want to make warden "think" we are getting user from session (this is the only way to make it skip `trackable`, `lockable`, and other sign-in-related hooks).

Please let me know if you have any questions or comments regarding this implementation.