### PR TITLE
Prevent bleeding of previous user's token with enable_standard_devise_support

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -37,7 +37,8 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     @client_id ||= 'default'
 
     # check for an existing user, authenticated via warden/devise, if enabled
-    if DeviseTokenAuth.enable_standard_devise_support
+    # but if we specify a uid or a token in the header, that takes precedence
+    if DeviseTokenAuth.enable_standard_devise_support && !uid && !@token
       devise_warden_user = warden.user(rc.to_s.underscore.to_sym)
       if devise_warden_user && devise_warden_user.tokens[@client_id].nil?
         @used_auth_by_token = false
@@ -47,7 +48,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     end
 
     # user has already been found and authenticated
-    return @resource if @resource && @resource.is_a? rc
+    return @resource if @resource && @resource.is_a?(rc)
 
     # ensure we clear the client_id
     if !@token

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -47,7 +47,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     end
 
     # user has already been found and authenticated
-    return @resource if @resource && @resource.class == rc
+    return @resource if @resource && @resource.is_a? rc
 
     # ensure we clear the client_id
     if !@token


### PR DESCRIPTION
Hi! Here are some thoughts that I had on this gem from using it in my projects:

- I found a bug with the option `enable_standard_devise_support` turned on where if you log in as user 1, log in as user 2, call the REST api with user 1's token, then call the REST api with user 2's token, the very last call that is made with user 2's token will execute as if the authenticated user is user 1. I believe this happens because warden aggressively caches the currently logged-in user, and this takes precedence over a explicitly stated token/uid in the header if the `enable_standard_devise_suport` is turned on. I would propose giving precedence to an explicitly set token/uid in the header or params, even if the `enable_standard_devise_support` option is turned on.

- The SetUserByToken does not play nicely with Single Table Inheritance because of a strict class check to see if the resource obtained through authorization is the same class name as our expected resource class. I propose relaxing the constraints of this check to a `.is_a?` rather than a strict `.class ==`.

Please let me know what you think! Your feedback will be very much appreciated!
