### PR TITLE
Feature/allow omini json override

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,24 @@ mount_devise_token_auth_for 'User', at: 'auth', controllers: {
 }
 ~~~
 
+## Overriding the Omniauth Success resource serializer
+
+Rendering an Omniauth success works a litte differently to the other controller which is why there is no render override. Instead we provide a method to override which defines how you want the resource (usually the user object) to be serialized. The default is:
+
+~~~ruby
+def omniauth_resource_serializer(resource)
+  resource.as_json
+end
+~~~
+
+But you may not want to use the built in `as_json`. In which case, you can override it like this, for example:
+
+~~~ruby
+def omniauth_resource_serializer(resource)
+  MyCustomSerializer.new(resource).return_a_hash
+end
+~~~
+
 **Note:** Controller overrides must implement the expected actions of the controllers that they replace.
 
 ## Passing blocks to Controllers

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -42,7 +42,7 @@ module DeviseTokenAuth
 
       yield @resource if block_given?
 
-      render_data_or_redirect('deliverCredentials', @auth_params.as_json, @resource.as_json)
+      render_data_or_redirect('deliverCredentials', @auth_params.as_json, omniauth_resource_serializer(@resource))
     end
 
     def omniauth_failure
@@ -51,6 +51,11 @@ module DeviseTokenAuth
     end
 
     protected
+
+    #override this method to provide your own serialization strategy
+    def omniauth_resource_serializer(resource)
+      resource.as_json
+    end
 
     # this will be determined differently depending on the action that calls
     # it. redirect_callbacks is called upon returning from successful omniauth


### PR DESCRIPTION
Hi there!

While using `devise_token_auth` with `Omniauth` I hit onto an issue where the user json being returned didn't match the schema used on my frontend vuejs app.

I couldn't find an easy way to "hook" into the gem without forking and/or copying and pasting the`omniauth_success` contents, which I didn't want to do because of possible future breaking changes.

I know there is a hook in there to pass a block, but if I somehow did that in there (like providing a proxy object or something)... it just feels wrong since it assumes knowledge of the underlying gem implementation.

Anyhow, this provide a simple method that can be overriden which is just for providing some way to serialize the resource object.

Yay 👍  or nay 👎 ?