### PR TITLE
Fix default provider after refactor in concern

### DIFF
--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -12,7 +12,7 @@ module DeviseTokenAuth::Concerns::ResourceFinder
     q_value
   end
 
-  def find_resource(field, value, provider='email')
+  def find_resource(field, value)
     # fix for mysql default case insensitivity
     q = "#{field.to_s} = ? AND provider='#{provider.to_s}'"
 
@@ -31,5 +31,9 @@ module DeviseTokenAuth::Concerns::ResourceFinder
     end
 
     mapping.to
+  end
+
+  def provider
+    'email'
   end
 end

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -132,12 +132,6 @@ module DeviseTokenAuth
       }, status: 404
     end
 
-    protected
-
-    def provider
-      'email'
-    end
-
     private
 
     def resource_params


### PR DESCRIPTION
This PR #971 broke my what I did on #964, because it added the provider as a default parameter instead of a overridable method. I can't add test with other providers because the method needs to be override (something done in a project that includes this gem), and I don't like to do monkeypatch testing.