### PR TITLE
Add link to wiki of how to add fields for an existing user table

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,11 @@ end
 
 You may be interested in [GrapeTokenAuth](https://github.com/mcordell/grape_token_auth) or [GrapeDeviseTokenAuth](https://github.com/mcordell/grape_devise_token_auth).
 
+### I already have an user, how can I add the new fields?
+
+Check [Setup migrations for an existing User table](https://github.com/lynndylanhurley/devise_token_auth/wiki/Setup-migrations-for-an-existing-User-table)
+
+
 # Conceptual
 
 None of the following information is required to use this gem, but read on if you're curious.


### PR DESCRIPTION
Resolves #181 

Thanks to @rruettimann !

You can make here any comments about the [wiki](https://github.com/lynndylanhurley/devise_token_auth/wiki/Setup-migrations-for-an-existing-User-table), and I will address them. If you are a contributor, you can edit it.

Note: we should move more things from the README to the wiki, it's too long