### PR TITLE
Refactor render error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ cache: bundler
 sudo: false
 
 rvm:
+  - 2.2.8
   - 2.3.1
+  - 2.4.2
 
 env:
   global:

--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -5,7 +5,7 @@ module DeviseTokenAuth
 
     def resource_data(opts={})
       response_data = opts[:resource_json] || @resource.as_json
-      if is_json_api
+      if json_api?
         response_data['type'] = @resource.class.name.parameterize
       end
       response_data
@@ -48,7 +48,7 @@ module DeviseTokenAuth
       mapping.to
     end
 
-    def is_json_api
+    def json_api?
       return false unless defined?(ActiveModel::Serializer)
       return ActiveModel::Serializer.setup do |config|
         config.adapter == :json_api
@@ -64,5 +64,13 @@ module DeviseTokenAuth
       resource_class.devise_modules.include?(:confirmable)
     end
 
+    def render_error(status, message, data = nil)
+      response = {
+        success: false,
+        errors: [message]
+      }
+      response = response.merge(data) if data
+      render json: response, status: status
+    end
   end
 end

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -112,19 +112,21 @@ module DeviseTokenAuth
     protected
 
     def render_create_error_missing_confirm_success_url
-      render json: {
+      response = {
         status: 'error',
-        data:   resource_data,
-        errors: [I18n.t("devise_token_auth.registrations.missing_confirm_success_url")]
-      }, status: 422
+        data:   resource_data
+      }
+      message = I18n.t("devise_token_auth.registrations.missing_confirm_success_url")
+      render_error(422, message, response)
     end
 
     def render_create_error_redirect_url_not_allowed
-      render json: {
+      response = {
         status: 'error',
-        data:   resource_data,
-        errors: [I18n.t("devise_token_auth.registrations.redirect_url_not_allowed", redirect_url: @redirect_url)]
-      }, status: 422
+        data:   resource_data
+      }
+      message = I18n.t("devise_token_auth.registrations.redirect_url_not_allowed", redirect_url: @redirect_url)
+      render_error(422, message, response)
     end
 
     def render_create_success
@@ -143,11 +145,12 @@ module DeviseTokenAuth
     end
 
     def render_create_error_email_already_exists
-      render json: {
+      response = {
         status: 'error',
-        data:   resource_data,
-        errors: [I18n.t("devise_token_auth.registrations.email_already_exists", email: @resource.email)]
-      }, status: 422
+        data:   resource_data
+      }
+      message = I18n.t("devise_token_auth.registrations.email_already_exists", email: @resource.email)
+      render_error(422, message, response)
     end
 
     def render_update_success
@@ -165,10 +168,7 @@ module DeviseTokenAuth
     end
 
     def render_update_error_user_not_found
-      render json: {
-        status: 'error',
-        errors: [I18n.t("devise_token_auth.registrations.user_not_found")]
-      }, status: 404
+      render_error(404, I18n.t("devise_token_auth.registrations.user_not_found"), { status: 'error' })
     end
 
     def render_destroy_success
@@ -179,10 +179,7 @@ module DeviseTokenAuth
     end
 
     def render_destroy_error
-      render json: {
-        status: 'error',
-        errors: [I18n.t("devise_token_auth.registrations.account_to_destroy_not_found")]
-      }, status: 404
+      render_error(404, I18n.t("devise_token_auth.registrations.account_to_destroy_not_found"), { status: 'error' })
     end
 
     private
@@ -208,10 +205,7 @@ module DeviseTokenAuth
     end
 
     def validate_post_data which, message
-      render json: {
-         status: 'error',
-         errors: [message]
-      }, status: :unprocessable_entity if which.empty?
+      render_error(:unprocessable_entity, message, { status: 'error' }) if which.empty?
     end
   end
 end

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -96,9 +96,7 @@ module DeviseTokenAuth
     end
 
     def render_new_error
-      render json: {
-        errors: [ I18n.t("devise_token_auth.sessions.not_supported")]
-      }, status: 405
+      render_error(405, I18n.t("devise_token_auth.sessions.not_supported"))
     end
 
     def render_create_success
@@ -108,16 +106,11 @@ module DeviseTokenAuth
     end
 
     def render_create_error_not_confirmed
-      render json: {
-        success: false,
-        errors: [ I18n.t("devise_token_auth.sessions.not_confirmed", email: @resource.email) ]
-      }, status: 401
+      render_error(401, I18n.t("devise_token_auth.sessions.not_confirmed", email: @resource.email))
     end
 
     def render_create_error_bad_credentials
-      render json: {
-        errors: [I18n.t("devise_token_auth.sessions.bad_credentials")]
-      }, status: 401
+      render_error(401, I18n.t("devise_token_auth.sessions.bad_credentials"))
     end
 
     def render_destroy_success
@@ -127,9 +120,7 @@ module DeviseTokenAuth
     end
 
     def render_destroy_error
-      render json: {
-        errors: [I18n.t("devise_token_auth.sessions.user_not_found")]
-      }, status: 404
+      render_error(404, I18n.t("devise_token_auth.sessions.user_not_found"))
     end
 
     private

--- a/app/controllers/devise_token_auth/token_validations_controller.rb
+++ b/app/controllers/devise_token_auth/token_validations_controller.rb
@@ -23,10 +23,7 @@ module DeviseTokenAuth
     end
 
     def render_validate_token_error
-      render json: {
-        success: false,
-        errors: [I18n.t("devise_token_auth.token_validations.invalid")]
-      }, status: 401
+      render_error(401, I18n.t("devise_token_auth.token_validations.invalid"))
     end
   end
 end

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -166,7 +166,7 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
               @uid            = @qs['uid']
             end
 
-            test 'respones should have success redirect status' do
+            test 'response should have success redirect status' do
               assert_equal 302, response.status
             end
 


### PR DESCRIPTION
This PR includes:
- Resolves #987, now it's possible edit/disable 404 error in passwords#create
- Refactor the errors rendering (not the resource's errors), so it's possible to change how to return them. In my opinion, we shouldn't be using `errors` for an array with a message, in the frontend you have to ask if it's an array vs hash (instead of asking error vs errors), it's kind of ugly. As I don't know if I can make that change (because I can break ng-token-auth), I moved how the errors are returned to a method.
- Removed @error_status and @errors from passwords/unlocks controller, they made the possible flows more complex
- Added Ruby 2.2 and 2.4 to Travis, so we can support more rubys.
- Renamed `is_json_api`, following the [ruby style guide](https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark)