### PR TITLE
Check if recoverable is enabled in case allow_password_change is used

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,4 +28,4 @@ bundle exec guard
 
 Guard will re-run each test suite when changes are made to its corresponding files.
 
-To run **just one test**: Flavio Castelli blogged about [how to execute a single unit test (or even a single test method)](https://webcache.googleusercontent.com/search?q=cache:lVNaE5lsPq0J:http://flavio.castelli.name/2010/05/28/rails_execute_single_test%2Bflavio.castelli.name/2010/05/28/rails_execute_single_test+!g&num=1&hl=en&strip=1&vwsrc=0) instead of running the complete unit test suite.
+To run **just one test**: Flavio Castelli blogged about [how to execute a single unit test (or even a single test method)](https://flavio.castelli.me/2010/05/28/rails_execute_single_test/) instead of running the complete unit test suite.

--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -42,5 +42,13 @@ module DeviseTokenAuth
       return ActiveModelSerializers.config.adapter == :json_api
     end
 
+    def recoverable_enabled?
+      resource_class.devise_modules.include?(:recoverable)
+    end
+
+    def confirmable_enabled?
+      resource_class.devise_modules.include?(:confirmable)
+    end
+
   end
 end

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -31,7 +31,7 @@ module DeviseTokenAuth
       set_token_on_resource
       create_auth_params
 
-      if resource_class.devise_modules.include?(:confirmable)
+      if confirmable_enabled?
         # don't send confirmation email!!!
         @resource.skip_confirmation!
       end

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -23,7 +23,7 @@ module DeviseTokenAuth
       @redirect_url ||= DeviseTokenAuth.default_confirm_success_url
 
       # success redirect url is required
-      if resource_class.devise_modules.include?(:confirmable) && !@redirect_url
+      if confirmable_enabled? && !@redirect_url
         return render_create_error_missing_confirm_success_url
       end
 


### PR DESCRIPTION
Because projects that update the gem won't have the new field `allow_password_change`, this prevents asking if the recoverable module is added. Also, I fixed the broken url of running a single test.