### PR TITLE
Fixes include bug causing sign_in to require auth

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -1,7 +1,6 @@
 module DeviseTokenAuth::Concerns::SetUserByToken
   extend ActiveSupport::Concern
   include DeviseTokenAuth::Concerns::ResourceFinder
-  include DeviseTokenAuth::Controllers::Helpers
 
   included do
     before_action :set_request_start


### PR DESCRIPTION
This fixes #1014, #887 and probably some more issues. 

I'm not sure why that line was included in that file in the first place. It is already being loaded inside `DeviseTokenAuth::Concerns::ResourceFinder` which also is included. 

Now I am successfully able to run devise alongside devise_token_auth. 

Leave my ApplicationController untouched:

```ruby
class ApplicationController < ActionController::Base
  protect_from_forgery with: :exception
  before_action :authenticate_user!
end
```

and use another controller for the Api: 

```ruby
class Api::ApiController < ActionController::Base
  include DeviseTokenAuth::Concerns::SetUserByToken
end
```

routes: 
```ruby
namespace :api, defaults: { format: 'json' } do
  scope :v1 do
    mount_devise_token_auth_for 'User', at: 'auth', controllers: { sessions: "users/sessions" }
    resources :test, only: :index
  end
end
```