### PR TITLE
Honor strip_whitespace_keys from devise config

### DIFF
--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -9,6 +9,10 @@ module DeviseTokenAuth::Concerns::ResourceFinder
     if resource_class.case_insensitive_keys.include?(field.to_sym)
       q_value.downcase!
     end
+
+    if resource_class.strip_whitespace_keys.include?(field.to_sym)
+      q_value.strip!
+    end
     q_value
   end
 

--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -13,6 +13,7 @@ module DeviseTokenAuth::Concerns::ResourceFinder
     if resource_class.strip_whitespace_keys.include?(field.to_sym)
       q_value.strip!
     end
+
     q_value
   end
 

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -239,6 +239,29 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
           assert_equal 401, response.status
         end
       end
+
+      describe 'stripping whitespace on email' do
+        before do
+          @resource_class = User
+          @request_params = {
+            # adding whitespace before and after email
+            email: " #{@existing_user.email}  ".upcase,
+            password: 'secret123'
+          }
+        end
+
+        test 'request should succeed if configured' do
+          @resource_class.strip_whitespace_keys = [:email]
+          post :create, params: @request_params
+          assert_equal 200, response.status
+        end
+
+        test 'request should fail if not configured' do
+          @resource_class.strip_whitespace_keys = []
+          post :create, params: @request_params
+          assert_equal 401, response.status
+        end
+      end
     end
 
     describe 'Unconfirmed user' do

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -245,7 +245,7 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
           @resource_class = User
           @request_params = {
             # adding whitespace before and after email
-            email: " #{@existing_user.email}  ".upcase,
+            email: " #{@existing_user.email}  ",
             password: 'secret123'
           }
         end


### PR DESCRIPTION
Hello,
in our application  some (clumsy?) users are including whitespace before or after their email address when trying to log in, and failing (credentials were being rejected). We are also not stripping the whitespace in the front-end.

Based on our understanding, it seems that `devise_token_auth` is not honoring the `strip_whitespace_keys` as set in `config/initializers/devise.rb`.

This small patch will strip whitespace according to the `strip_whitespace_keys` configuration.

(tested and passing on Ruby 2.4.1)

Hope to help, thanks for this great gem!
Marco