### PR TITLE
Fix bypass_sign_in broken tests

### DIFF
--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -424,7 +424,7 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
         before do
           age_token(@resource, @client_id)
 
-          get '/demo/members_only', {}, @auth_headers
+          get '/demo/members_only', params: {}, headers: @auth_headers
 
           @access_token = response.headers['access-token']
           @response_status = response.status
@@ -447,7 +447,7 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
           DeviseTokenAuth.bypass_sign_in = false
           age_token(@resource, @client_id)
 
-          get '/demo/members_only', {}, @auth_headers
+          get '/demo/members_only', params: {}, headers: @auth_headers
 
           @access_token = response.headers['access-token']
           @response_status = response.status


### PR DESCRIPTION
Fixed tests that #911 broke in master. I should have rebuilt travis for that PR before merge because it had a long time opened, now I learned the lesson