### PR TITLE
#155 fix authenticate_#{mapping} definition

### DIFF
--- a/lib/devise_token_auth/controllers/helpers.rb
+++ b/lib/devise_token_auth/controllers/helpers.rb
@@ -113,7 +113,7 @@ module DeviseTokenAuth
         mapping = mapping.name
 
         class_eval <<-METHODS, __FILE__, __LINE__ + 1
-          def authenticate_#{mapping}!
+          def authenticate_#{mapping}!(opts={})
             unless current_#{mapping}
               render_authenticate_error
             end


### PR DESCRIPTION
#155 Fixed the signature of authenticate_#{mapping}! method.
In Devise authenticate_#{mapping}! method accepts 1 argument opts. As devise_token_auth 's intention is to override this method hence the signature should be same.