### PR TITLE
Remove verbose warnings in test output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
+  t.warning = false
 end
 
 

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -100,6 +100,12 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     else
 
+      if @resource.changed?
+        # Stash pending changes in the resource before reloading.
+        changes = @resource.changes
+        @resource.reload
+      end
+
       # Lock the user record during any auth_header updates to ensure
       # we don't have write contention from multiple threads
       @resource.with_lock do
@@ -135,6 +141,8 @@ module DeviseTokenAuth::Concerns::SetUserByToken
         response.headers.merge!(auth_header)
 
       end # end lock
+      # Reapply pending changes if any
+      @resource.assign_attributes(changes) if changes
 
     end
 

--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -276,11 +276,13 @@ class OmniauthTest < ActionDispatch::IntegrationTest
     end
 
     test 'renders expected data' do
-      get '/auth/facebook',
-          params: { auth_origin_url: @redirect_url,
-                    omniauth_window_type: 'newWindow' }
+      silence_omniauth do
+        get '/auth/facebook',
+            params: { auth_origin_url: @redirect_url,
+                      omniauth_window_type: 'newWindow' }
 
-      follow_all_redirects!
+        follow_all_redirects!
+      end
 
       assert_equal 200, response.status
 
@@ -290,8 +292,10 @@ class OmniauthTest < ActionDispatch::IntegrationTest
     end
 
     test 'renders something with no auth_origin_url' do
-      get '/auth/facebook'
-      follow_all_redirects!
+      silence_omniauth do
+        get '/auth/facebook'
+        follow_all_redirects!
+      end
       assert_equal 200, response.status
       assert_select 'body', 'invalid_credentials'
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,15 @@ class ActiveSupport::TestCase
       user.save!
     end
   end
+
+  # Suppress OmniAuth logger output
+  def silence_omniauth
+    previous_logger = OmniAuth.config.logger
+    OmniAuth.config.logger = Logger.new("/dev/null")
+    yield
+  ensure
+    OmniAuth.config.logger = previous_logger
+  end
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
A fix for issue #976.

This removes most of the verbose warnings shown when running `rake test`.