### PR TITLE
fixing ActiveModel::ForbiddenAttributesError on oAuth login

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -79,8 +79,8 @@ module DeviseTokenAuth
 
     # break out provider attribute assignment for easy method extension
     def assign_provider_attrs(user, auth_hash)
-      attrs = auth_hash['info'].slice(*user.attributes.keys)
-      user.assign_attributes(attrs)
+      attrs = auth_hash['info'].slice(*user.attributes.keys).to_hash
+      user.update_attributes(attrs)
     end
 
     # derive allowed params from the standard devise parameter sanitizer


### PR DESCRIPTION
I'm using the gem with rails 5.1.1 in api only mode with https://github.com/neroniaky/angular2-token. It works like a charm - but the oauth made some trouble.

Like in issue #1018 I got the _ActiveModel::ForbiddenAttributesError: ActiveModel::ForbiddenAttributesError_ on every login via oauth (tested with twitter and facebook). 

This PR solved the oauth login for me and I got all things back working.
