### PR TITLE
Separate error messages for missing vs invalid email

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -2,7 +2,8 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
   extend ActiveSupport::Concern
 
   included do
-    validates :email, presence: true, email: true, if: :email_provider?
+    validates :email, presence: true,if: :email_provider?
+    validates :email, email: true, allow_nil: true, allow_blank: true, if: :email_provider?
     validates_presence_of :uid, unless: :email_provider?
 
     # only validate unique emails among email registration users

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -31,7 +31,17 @@ class UserTest < ActiveSupport::TestCase
         @resource.password_confirmation = @password
 
         refute @resource.save
-        assert @resource.errors.messages[:email]
+        assert @resource.errors.messages[:email] == [I18n.t("errors.messages.blank")]
+      end
+
+      test 'model should not save if email is not an email' do
+        @resource.provider              = 'email'
+        @resource.email                 = '@example.com'
+        @resource.password              = @password
+        @resource.password_confirmation = @password
+
+        refute @resource.save
+        assert @resource.errors.messages[:email] == [I18n.t("errors.messages.not_email")]
       end
     end
 


### PR DESCRIPTION
When you submit a missing email, you should only get an error message that it's missing, not that it's missing and that it's an invalid format.