### PR TITLE
chore(deps): expand devise to allow < 4.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ PATH
   remote: .
   specs:
     devise_token_auth (0.1.43.beta1)
-      devise (> 3.5.2, < 4.4)
+      devise (> 3.5.2, < 4.5)
       rails (< 6)
 
 GEM
@@ -89,8 +89,8 @@ GEM
       simplecov (<= 0.13)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
-    crass (1.0.2)
-    devise (4.3.0)
+    crass (1.0.3)
+    devise (4.4.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.2)
@@ -116,7 +116,7 @@ GEM
       rainbow (>= 2.1)
       rake (>= 10.0)
       retriable (~> 2.1)
-    globalid (0.4.0)
+    globalid (0.4.1)
       activesupport (>= 4.2.0)
     guard (2.14.1)
       formatador (>= 0.2.4)
@@ -132,7 +132,8 @@ GEM
       guard-compat (~> 1.2)
       minitest (>= 3.0)
     hashie (3.5.5)
-    i18n (0.8.6)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     jwt (1.5.6)
     listen (3.1.5)
@@ -143,15 +144,13 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
+    minitest (5.11.1)
     minitest-focus (1.1.2)
       minitest (>= 4, < 6)
     minitest-rails (3.0.0)
@@ -169,7 +168,7 @@ GEM
     multipart-post (2.0.0)
     mysql2 (0.4.6)
     nenv (0.3.0)
-    nio4r (2.1.0)
+    nio4r (2.2.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
@@ -201,7 +200,7 @@ GEM
     public_suffix (2.0.5)
     rack (2.0.3)
     rack-cors (0.4.1)
-    rack-test (0.7.0)
+    rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rails (5.1.4)
       actioncable (= 5.1.4)
@@ -232,7 +231,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.1.0)
+    rake (12.3.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -262,13 +261,13 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
 
 PLATFORMS
   ruby
@@ -301,4 +300,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files.reject! { |file| file.match(/[.log|.sqlite3]$/) }
 
   s.add_dependency "rails", "< 6"
-  s.add_dependency "devise", "> 3.5.2", "< 4.4"
+  s.add_dependency "devise", "> 3.5.2", "< 4.5"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency 'pg'


### PR DESCRIPTION
Ruby 2.5.0 errors on devise 4.3, so need upgrade to 4.4
https://github.com/plataformatec/devise/issues/4736