### PR TITLE
Make confirmable not dependant on trackable

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -10,7 +10,7 @@ module DeviseTokenAuth
         token_hash = BCrypt::Password.create(token)
         expiry     = (Time.now + @resource.token_lifespan).to_i
 
-        if @resource.sign_in_count > 0
+        if defined? @resource.sign_in_count && @resource.sign_in_count > 0
           expiry = (Time.now + 1.second).to_i
         end
 


### PR DESCRIPTION
Hello,

At the moment we have confirmable dependant on trackable because it excplicitly calls sign_in_count column while confirming email, but one should have an ability to use it without trackable module