### PR TITLE
Fix checking for presence #sign_in_count on resource in confirmations

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -10,7 +10,7 @@ module DeviseTokenAuth
         token_hash = BCrypt::Password.create(token)
         expiry     = (Time.now + @resource.token_lifespan).to_i
 
-        if defined? @resource.sign_in_count && @resource.sign_in_count > 0
+        if defined?(@resource.sign_in_count) && @resource.sign_in_count > 0
           expiry = (Time.now + 1.second).to_i
         end
 


### PR DESCRIPTION
There is a bug reported in comments https://github.com/lynndylanhurley/devise_token_auth/pull/1064
Here is a pull request fixing the bug.
