### PR TITLE
Update user template

### DIFF
--- a/lib/generators/devise_token_auth/templates/user.rb
+++ b/lib/generators/devise_token_auth/templates/user.rb
@@ -1,7 +1,7 @@
 class <%= user_class.capitalize %> < ActiveRecord::Base
-  # Include default devise modules.
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-          :recoverable, :rememberable, :trackable, :validatable,
-          :confirmable, :omniauthable
+         :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 end


### PR DESCRIPTION
I copied the template that [is used by default in devise](https://github.com/plataformatec/devise/blob/master/lib/generators/devise/orm_helpers.rb#L10). The main reason I did this is that it was adding `omniauthable` by default, even if omniauth is not in the Gemfile.