### PR TITLE
Normalize session errors to align with regristration

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -67,7 +67,9 @@ module DeviseTokenAuth
     def render_error(status, message, data = nil)
       response = {
         success: false,
-        errors: [message]
+        errors: {
+          full_messages: [message]
+          }
       }
       response = response.merge(data) if data
       render json: response, status: status

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -30,7 +30,8 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
 
         test 'error message should be returned' do
           assert @data['errors']
-          assert_equal @data['errors'],
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'],
                        [I18n.t('devise_token_auth.passwords.missing_email')]
         end
       end
@@ -51,7 +52,8 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
 
         test 'error message should be returned' do
           assert @data['errors']
-          assert_equal @data['errors'],
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'],
                        [I18n.t('devise_token_auth.passwords.missing_redirect_url')]
         end
       end
@@ -71,7 +73,8 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
 
           test 'errors should be returned' do
             assert @data['errors']
-            assert_equal @data['errors'],
+            assert @data['errors']['full_messages']
+            assert_equal @data['errors']['full_messages'],
                          [I18n.t('devise_token_auth.passwords.user_not_found',
                                  email: 'chester@cheet.ah')]
           end
@@ -380,7 +383,8 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
 
           @data = JSON.parse(response.body)
           assert @data['errors']
-          assert_equal @data['errors'],
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'],
                        [I18n.t('devise_token_auth.passwords.not_allowed_redirect_url',
                                redirect_url: @bad_redirect_url)]
         end

--- a/test/controllers/devise_token_auth/registrations_controller_test.rb
+++ b/test/controllers/devise_token_auth/registrations_controller_test.rb
@@ -130,7 +130,8 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
 
         assert_equal 422, response.status
         assert @data['errors']
-        assert_equal @data['errors'],
+        assert @data['errors']['full_messages']
+        assert_equal @data['errors']['full_messages'],
                      [I18n.t('devise_token_auth.registrations.redirect_url_not_allowed',
                              redirect_url: @bad_redirect_url)]
       end
@@ -156,7 +157,9 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
         @data = JSON.parse(response.body)
 
         assert @data['errors']
-        assert_equal @data['errors'], [I18n.t('devise_token_auth.registrations.missing_confirm_success_url')]
+        assert @data['errors']['full_messages']
+        assert_equal @data['errors']['full_messages'], 
+          [I18n.t('devise_token_auth.registrations.missing_confirm_success_url')]
       end
     end
 
@@ -440,8 +443,10 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
         end
 
         test 'error should be returned' do
-          assert @data['errors'].length
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.registrations.account_to_destroy_not_found')]
+          assert @data['errors']
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
+            [I18n.t('devise_token_auth.registrations.account_to_destroy_not_found')]
         end
       end
     end
@@ -691,8 +696,10 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
         end
 
         test 'error should be returned' do
-          assert @data['errors'].length
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.registrations.user_not_found')]
+          assert @data['errors']
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'],
+            [I18n.t('devise_token_auth.registrations.user_not_found')]
         end
 
         test 'User should not be updated' do

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -87,7 +87,9 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
         end
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.sessions.not_supported')]
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
+            [I18n.t('devise_token_auth.sessions.not_supported')]
         end
       end
 
@@ -162,7 +164,8 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'],
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
                        [I18n.t('devise_token_auth.sessions.user_not_found')]
         end
       end
@@ -183,7 +186,8 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'],
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
                        [I18n.t('devise_token_auth.sessions.bad_credentials')]
         end
       end
@@ -210,7 +214,9 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.sessions.bad_credentials')]
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
+            [I18n.t('devise_token_auth.sessions.bad_credentials')]
         end
 
         after do
@@ -279,7 +285,8 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
       test 'response should contain errors' do
         assert @data['errors']
-        assert_equal @data['errors'],
+        assert @data['errors']['full_messages']
+        assert_equal @data['errors']['full_messages'], 
                      [I18n.t('devise_token_auth.sessions.not_confirmed',
                              email: @unconfirmed_user.email)]
       end
@@ -450,7 +457,9 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.sessions.not_confirmed', email: @locked_user.email)]
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
+            [I18n.t('devise_token_auth.sessions.not_confirmed', email: @locked_user.email)]
         end
       end
 
@@ -473,7 +482,9 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.sessions.bad_credentials')]
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
+            [I18n.t('devise_token_auth.sessions.bad_credentials')]
         end
 
         describe 'after maximum_attempts should block the user' do

--- a/test/controllers/devise_token_auth/token_validations_controller_test.rb
+++ b/test/controllers/devise_token_auth/token_validations_controller_test.rb
@@ -59,7 +59,8 @@ class DeviseTokenAuth::TokenValidationsControllerTest < ActionDispatch::Integrat
 
       test 'response should contain errors' do
         assert @resp['errors']
-        assert_equal @resp['errors'], [I18n.t('devise_token_auth.token_validations.invalid')]
+        assert @resp['errors']['full_messages']
+        assert_equal @resp['errors']['full_messages'], [I18n.t('devise_token_auth.token_validations.invalid')]
       end
     end
   end

--- a/test/controllers/devise_token_auth/unlocks_controller_test.rb
+++ b/test/controllers/devise_token_auth/unlocks_controller_test.rb
@@ -50,7 +50,9 @@ class DeviseTokenAuth::UnlocksControllerTest < ActionController::TestCase
         end
         test 'error message should be returned' do
           assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.passwords.missing_email')]
+          assert @data['errors']['full_messages']
+          assert_equal @data['errors']['full_messages'], 
+            [I18n.t('devise_token_auth.passwords.missing_email')]
         end
       end
 
@@ -66,7 +68,8 @@ class DeviseTokenAuth::UnlocksControllerTest < ActionController::TestCase
 
           test 'errors should be returned' do
             assert @data['errors']
-            assert_equal @data['errors'],
+            assert @data['errors']['full_messages']
+            assert_equal @data['errors']['full_messages'], 
                          [I18n.t('devise_token_auth.passwords.user_not_found',
                                  email: 'chester@cheet.ah')]
           end

--- a/test/dummy/app/controllers/overrides/registrations_controller.rb
+++ b/test/dummy/app/controllers/overrides/registrations_controller.rb
@@ -19,7 +19,9 @@ module Overrides
       else
         render json: {
           status: 'error',
-          errors: ["User not found."]
+          errors: {
+            full_messages: [I18n.t('devise_token_auth.registrations.user_not_found')]
+          }
         }, status: 404
       end
     end

--- a/test/dummy/app/controllers/overrides/sessions_controller.rb
+++ b/test/dummy/app/controllers/overrides/sessions_controller.rb
@@ -19,16 +19,16 @@ module Overrides
       elsif @resource and not @resource.confirmed?
         render json: {
           success: false,
-          errors: [
-            "A confirmation email was sent to your account at #{@resource.email}. "+
-            "You must follow the instructions in the email before your account "+
-            "can be activated"
-          ]
+          errors: {
+            full_messages: [I18n.t('devise_token_auth.sessions.not_confirmed', @resource.email)]
+          } 
         }, status: 401
 
       else
         render json: {
-          errors: ["Invalid login credentials. Please try again."]
+          errors: {
+            full_messages: [I18n.t('devise_token_auth.sessions.bad_credentials')]
+          }
         }, status: 401
       end
     end

--- a/test/dummy/app/controllers/overrides/token_validations_controller.rb
+++ b/test/dummy/app/controllers/overrides/token_validations_controller.rb
@@ -15,7 +15,9 @@ module Overrides
       else
         render json: {
           success: false,
-          errors: ["Invalid login credentials"]
+          errors: {
+            full_messages: [I18n.t('devise_token_auth.token_validations.invalid')]
+          }
         }, status: 401
       end
     end


### PR DESCRIPTION
There was inconsistency between error messages from session vs. registration validation. 

I've updated the session controller to follow the same pattern as the one used in registration. 

_Invalid password:_
```json
{
    "errors": [
        "Invalid login credentials. Please try again."
    ]
}
```

```json
{
    "errors": {
        "full_messages": [
            "Invalid login credentials. Please try again."
        ]
    },
    "success": false
}
```

(the added `success` key must be a change from the released gem to the master-branch checkout - but it does not match up with registration use of `error`)

**An error in registration:**
```json
{
    "data": {
        "created_at": null,
        "email": "stfnandersen14@gmail.com",
        "id": null,
        "provider": "email",
        "uid": "",
        "updated_at": null
    },
    "errors": {
        "full_messages": [
            "Password can't be blank"
        ],
        "password": [
            "can't be blank"
        ]
    },
    "status": "error"
}

```