### PR TITLE
confirmation should redirect to default_confirm_success_url by default

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -20,8 +20,15 @@ module DeviseTokenAuth
         redirect_headers = build_redirect_headers(token,
                                                   client_id,
                                                   redirect_header_options)
-        redirect_to(@resource.build_auth_url(params[:redirect_url],
-                                             redirect_headers))
+
+        # give redirect value from params priority
+        @redirect_url = params[:redirect_url]
+
+        # fall back to default value if provided
+        @redirect_url ||= DeviseTokenAuth.default_confirm_success_url
+
+
+        redirect_to(@resource.build_auth_url(@redirect_url, redirect_headers))
       else
         raise ActionController::RoutingError.new('Not Found')
       end


### PR DESCRIPTION
#1084 