### PR TITLE
Return locked out message from sessions controller when resource is locked

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -34,7 +34,11 @@ module DeviseTokenAuth
 
         render_create_success
       elsif @resource && !(!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
-        render_create_error_not_confirmed
+        if @resource.respond_to?(:locked_at) && @resource.locked_at
+          render_create_error_account_locked
+        else
+          render_create_error_not_confirmed
+        end
       else
         render_create_error_bad_credentials
       end
@@ -100,6 +104,10 @@ module DeviseTokenAuth
 
     def render_create_error_not_confirmed
       render_error(401, I18n.t("devise_token_auth.sessions.not_confirmed", email: @resource.email))
+    end
+
+    def render_create_error_account_locked
+      render_error(401, I18n.t("devise.mailer.unlock_instructions.account_lock_msg"))
     end
 
     def render_create_error_bad_credentials

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -22,8 +22,7 @@ module DeviseTokenAuth
       if @resource && valid_params?(field, q_value) && (!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
         valid_password = @resource.valid_password?(resource_params[:password])
         if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
-          render_create_error_bad_credentials
-          return
+         return render_create_error_bad_credentials
         end
         @client_id, @token = @resource.create_token
         @resource.save

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -450,7 +450,7 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
 
         test 'response should contain errors' do
           assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise_token_auth.sessions.not_confirmed', email: @locked_user.email)]
+          assert_equal @data['errors'], [I18n.t('devise.mailer.unlock_instructions.account_lock_msg')]
         end
       end
 


### PR DESCRIPTION
### Why?
Currently, when a user account is locked, devise token auth returns an error stating:
```
A confirmation email was sent to your account at user@example.com.
You must follow the instructions in the email before your account can be activated
```
This message can be misleading, especially when the `:confirmable` module is not in use.

### What Changed?
When an account is locked devise token auth now returns this message:
```
Your account has been locked due to an excessive number of unsuccessful sign in attempts.
```