### PR TITLE
Refactor uses of time now

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Models that include the `DeviseTokenAuth::Concerns::User` concern will have acce
   # store client + token in user's token hash
   @resource.tokens[client_id] = {
     token: BCrypt::Password.create(token),
-    expiry: (Time.now + @resource.token_lifespan).to_i
+    expiry: (Time.zone.now + @resource.token_lifespan).to_i
   }
 
   # generate auth headers for response

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -11,7 +11,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
   # keep track of request duration
   def set_request_start
-    @request_started_at = Time.now
+    @request_started_at = Time.zone.now
     @used_auth_by_token = true
 
     # initialize instance variables

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -6,7 +6,7 @@ module DeviseTokenAuth
       if @resource && @resource.id
         expiry = nil
         if defined?(@resource.sign_in_count) && @resource.sign_in_count > 0
-          expiry = (Time.now + 1.second).to_i
+          expiry = (Time.zone.now + 1.second).to_i
         end
 
         client_id, token = @resource.create_token expiry: expiry

--- a/lib/generators/devise_token_auth/USAGE
+++ b/lib/generators/devise_token_auth/USAGE
@@ -15,7 +15,7 @@ Example:
 
   This will create:
       config/initializers/devise_token_auth.rb
-      db/migrate/<%= Time.now.utc.strftime("%Y%m%d%H%M%S") %>_create_devise_token_auth_create_users.rb
+      db/migrate/<%= Time.zone.now.utc.strftime("%Y%m%d%H%M%S") %>_create_devise_token_auth_create_users.rb
       app/models/user.rb
 
   If 'app/models/user.rb' already exists, the following line will be inserted

--- a/lib/generators/devise_token_auth/install_generator.rb
+++ b/lib/generators/devise_token_auth/install_generator.rb
@@ -101,7 +101,7 @@ module DeviseTokenAuth
     private
 
     def self.next_migration_number(path)
-      Time.now.utc.strftime("%Y%m%d%H%M%S")
+      Time.zone.now.utc.strftime("%Y%m%d%H%M%S")
     end
 
     def insert_after_line(filename, line, str)

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -55,17 +55,13 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
         test 'the sign_in_count should be 1' do
           assert @resource.sign_in_count == 1
         end
+
         test 'User shoud have the signed in info filled' do
           assert @resource.current_sign_in_at?
         end
+
         test 'User shoud have the Last checkin filled' do
           assert @resource.last_sign_in_at?
-        end
-        
-        test 'user already confirmed' do
-          assert @resource.sign_in_count > 0 do
-            assert expiry == (Time.now + Time.now + 1.second).to_i
-          end
         end
       end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -94,7 +94,7 @@ class UserTest < ActiveSupport::TestCase
       test 'should properly indicate whether token is current' do
         assert @resource.token_is_current?(@token, @client_id)
         # we want to update the expiry without forcing a cleanup (see below)
-        @resource.tokens[@client_id]['expiry'] = Time.now.to_i - 10.seconds
+        @resource.tokens[@client_id]['expiry'] = Time.zone.now.to_i - 10.seconds
         refute @resource.token_is_current?(@token, @client_id)
       end
     end
@@ -121,7 +121,7 @@ class UserTest < ActiveSupport::TestCase
       test 'works per user' do
         assert @resource.token_is_current?(@token_global, @client_id_global)
 
-        time = Time.now.to_i
+        time = Time.zone.now.to_i
         expiry_global = @resource.tokens[@client_id_global]['expiry']
 
         assert expiry_global > time + DeviseTokenAuth.token_lifespan - 5.seconds

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,14 +45,14 @@ class ActiveSupport::TestCase
 
   def age_token(user, client_id)
     if user.tokens[client_id]
-      user.tokens[client_id]['updated_at'] = Time.now - (DeviseTokenAuth.batch_request_buffer_throttle + 10.seconds)
+      user.tokens[client_id]['updated_at'] = Time.zone.now - (DeviseTokenAuth.batch_request_buffer_throttle + 10.seconds)
       user.save!
     end
   end
 
   def expire_token(user, client_id)
     if user.tokens[client_id]
-      user.tokens[client_id]['expiry'] = (Time.now - (DeviseTokenAuth.token_lifespan.to_f + 10.seconds)).to_i
+      user.tokens[client_id]['expiry'] = (Time.zone.now - (DeviseTokenAuth.token_lifespan.to_f + 10.seconds)).to_i
       user.save!
     end
   end


### PR DESCRIPTION
Fixes #1112 by replacing all instances of `Time.now` with `Time.zone.now`.

I also removed a duplicate test from `test/controllers/devise_token_auth/confirmations_controller_test.rb` that included a block that was never run.