### PR TITLE
Support namespace

### DIFF
--- a/lib/generators/devise_token_auth/install_generator.rb
+++ b/lib/generators/devise_token_auth/install_generator.rb
@@ -12,12 +12,12 @@ module DeviseTokenAuth
     end
 
     def copy_migrations
-      if self.class.migration_exists?("db/migrate", "devise_token_auth_create_#{ user_class.underscore }")
-        say_status("skipped", "Migration 'devise_token_auth_create_#{ user_class.underscore }' already exists")
+      if self.class.migration_exists?("db/migrate", "devise_token_auth_create_#{ user_class.pluralize.gsub("::","").underscore }")
+        say_status("skipped", "Migration 'devise_token_auth_create_#{ user_class.pluralize.gsub("::","").underscore }' already exists")
       else
         migration_template(
           "devise_token_auth_create_users.rb.erb",
-          "db/migrate/devise_token_auth_create_#{ user_class.pluralize.underscore }.rb"
+          "db/migrate/devise_token_auth_create_#{ user_class.pluralize.gsub("::","").underscore }.rb"
         )
       end
     end
@@ -29,7 +29,7 @@ module DeviseTokenAuth
       else
         inclusion = "include DeviseTokenAuth::Concerns::User"
         unless parse_file_for_line(fname, inclusion)
-          
+
           active_record_needle = (Rails::VERSION::MAJOR == 5) ? 'ApplicationRecord' : 'ActiveRecord::Base'
           inject_into_file fname, after: "class #{user_class} < #{active_record_needle}\n" do <<-'RUBY'
   # Include default devise modules.

--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -1,6 +1,7 @@
-class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration<%= "[#{Rails::VERSION::STRING[0..2]}]" if Rails::VERSION::MAJOR > 4 %>
+class DeviseTokenAuthCreate<%= user_class.pluralize.gsub("::","") %> < ActiveRecord::Migration<%= "[#{Rails::VERSION::STRING[0..2]}]" if Rails::VERSION::MAJOR > 4 %>
   def change
-    create_table(:<%= user_class.pluralize.underscore %>) do |t|
+    <% table_name = @user_class.pluralize.gsub("::","").underscore %>
+    create_table(:<%= table_name %>) do |t|
       ## Required
       t.string :provider, :null => false, :default => "email"
       t.string :uid, :null => false, :default => ""
@@ -46,10 +47,10 @@ class DeviseTokenAuthCreate<%= user_class.pluralize %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= user_class.pluralize.underscore %>, :email,                unique: true
-    add_index :<%= user_class.pluralize.underscore %>, [:uid, :provider],     unique: true
-    add_index :<%= user_class.pluralize.underscore %>, :reset_password_token, unique: true
-    add_index :<%= user_class.pluralize.underscore %>, :confirmation_token,   unique: true
-    # add_index :<%= user_class.pluralize.underscore %>, :unlock_token,       unique: true
+    add_index :<%= table_name %>, :email,                unique: true
+    add_index :<%= table_name %>, [:uid, :provider],     unique: true
+    add_index :<%= table_name %>, :reset_password_token, unique: true
+    add_index :<%= table_name %>, :confirmation_token,   unique: true
+    # add_index :<%= table_name %>, :unlock_token,       unique: true
   end
 end

--- a/lib/generators/devise_token_auth/templates/user.rb
+++ b/lib/generators/devise_token_auth/templates/user.rb
@@ -1,4 +1,5 @@
-class <%= user_class.capitalize %> < ActiveRecord::Base
+
+class <%= user_class %> < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/test/lib/generators/devise_token_auth/install_generator_with_namespace_test.rb
+++ b/test/lib/generators/devise_token_auth/install_generator_with_namespace_test.rb
@@ -1,0 +1,192 @@
+require 'test_helper'
+require 'fileutils'
+require 'generators/devise_token_auth/install_generator'
+
+module DeviseTokenAuth
+  class InstallGeneratorTest < Rails::Generators::TestCase
+    tests InstallGenerator
+    destination Rails.root.join('tmp/generators')
+
+    # The namespaced user model for testing
+    let(:user_class) { "Azpire::V1::HumanResource::User" }
+    let(:namespace_path) { user_class.underscore }
+    let(:table_name) { user_class.pluralize.underscore.gsub("/","_") }
+
+    describe 'default values, clean install' do
+      setup :prepare_destination
+
+      before do
+        run_generator %W(#{user_class} auth)
+      end
+
+      test 'user model is created, concern is included' do
+        assert_file "app/models/#{namespace_path}.rb" do |model|
+          assert_match(/include DeviseTokenAuth::Concerns::User/, model)
+        end
+      end
+
+      test 'initializer is created' do
+        assert_file 'config/initializers/devise_token_auth.rb'
+      end
+
+      test 'migration is created' do
+        assert_migration "db/migrate/devise_token_auth_create_#{table_name}.rb"
+      end
+
+      test 'migration file contains rails version' do
+        if Rails::VERSION::MAJOR >= 5
+          assert_migration "db/migrate/devise_token_auth_create_#{table_name}.rb", /#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}/
+        else
+          assert_migration "db/migrate/devise_token_auth_create_#{table_name}.rb"
+        end
+      end
+
+      test 'subsequent runs raise no errors' do
+        run_generator %W(#{user_class} auth)
+      end
+    end
+
+    describe 'existing user model' do
+      setup :prepare_destination
+
+      before do
+        @dir = File.join(destination_root, "app", "models")
+
+        @fname = File.join(@dir, "user.rb")
+
+        # make dir if not exists
+        FileUtils.mkdir_p(@dir)
+
+        # account for rails version 5
+        active_record_needle = (Rails::VERSION::MAJOR == 5) ? 'ApplicationRecord' : 'ActiveRecord::Base'
+
+        @f = File.open(@fname, 'w') {|f|
+          f.write <<-RUBY
+            class User < #{active_record_needle}
+
+              def whatever
+                puts 'whatever'
+              end
+            end
+          RUBY
+        }
+
+        run_generator
+      end
+
+      test 'user concern is injected into existing model' do
+        assert_file 'app/models/user.rb' do |model|
+          assert_match(/include DeviseTokenAuth::Concerns::User/, model)
+        end
+      end
+
+      test 'subsequent runs do not modify file' do
+        run_generator
+        assert_file 'app/models/user.rb' do |model|
+          matches = model.scan(/include DeviseTokenAuth::Concerns::User/m).size
+          assert_equal 1, matches
+        end
+      end
+    end
+
+
+    describe 'routes' do
+      setup :prepare_destination
+
+      before do
+        @dir = File.join(destination_root, "config")
+
+        @fname = File.join(@dir, "routes.rb")
+
+        # make dir if not exists
+        FileUtils.mkdir_p(@dir)
+
+        @f = File.open(@fname, 'w') {|f|
+          f.write <<-RUBY
+            Rails.application.routes.draw do
+              patch '/chong', to: 'bong#index'
+            end
+          RUBY
+        }
+
+        run_generator %W(#{user_class} auth)
+      end
+
+      test 'route method is appended to routes file' do
+        assert_file 'config/routes.rb' do |routes|
+          assert_match(/mount_devise_token_auth_for '#{user_class}', at: 'auth'/, routes)
+        end
+      end
+
+      test 'subsequent runs do not modify file' do
+        run_generator %W(#{user_class} auth)
+        assert_file 'config/routes.rb' do |routes|
+          matches = routes.scan(/mount_devise_token_auth_for '#{user_class}', at: 'auth'/m).size
+          assert_equal 1, matches
+        end
+      end
+
+      describe 'subsequent models' do
+        before do
+          run_generator %w(Mang mangs)
+        end
+
+        test 'migration is created' do
+          assert_migration 'db/migrate/devise_token_auth_create_mangs.rb'
+        end
+
+        test 'route method is appended to routes file' do
+          assert_file 'config/routes.rb' do |routes|
+            assert_match(/mount_devise_token_auth_for 'Mang', at: 'mangs'/, routes)
+          end
+        end
+
+        test 'devise_for block is appended to routes file' do
+          assert_file 'config/routes.rb' do |routes|
+            assert_match(/as :mang do/, routes)
+            assert_match(/# Define routes for Mang within this block./, routes)
+          end
+        end
+      end
+    end
+
+    describe 'application controller' do
+      setup :prepare_destination
+
+      before do
+        @dir = File.join(destination_root, "app", "controllers")
+
+        @fname = File.join(@dir, "application_controller.rb")
+
+        # make dir if not exists
+        FileUtils.mkdir_p(@dir)
+
+        @f = File.open(@fname, 'w') {|f|
+          f.write <<-RUBY
+            class ApplicationController < ActionController::Base
+              def whatever
+                'whatever'
+              end
+            end
+          RUBY
+        }
+
+        run_generator %W(#{user_class} auth)
+      end
+
+      test 'controller concern is appended to application controller' do
+        assert_file 'app/controllers/application_controller.rb' do |controller|
+          assert_match(/include DeviseTokenAuth::Concerns::SetUserByToken/, controller)
+        end
+      end
+
+      test 'subsequent runs do not modify file' do
+        run_generator %W(#{user_class} auth)
+        assert_file 'app/controllers/application_controller.rb' do |controller|
+          matches = controller.scan(/include DeviseTokenAuth::Concerns::SetUserByToken/m).size
+          assert_equal 1, matches
+        end
+      end
+    end
+  end
+end

--- a/test/lib/generators/devise_token_auth/install_generator_with_namespace_test.rb
+++ b/test/lib/generators/devise_token_auth/install_generator_with_namespace_test.rb
@@ -12,14 +12,14 @@ module DeviseTokenAuth
     let(:namespace_path) { user_class.underscore }
     let(:table_name) { user_class.pluralize.underscore.gsub("/","_") }
 
-    describe 'default values, clean install' do
+    describe 'user model with namespace, clean install' do
       setup :prepare_destination
 
       before do
         run_generator %W(#{user_class} auth)
       end
 
-      test 'user model is created, concern is included' do
+      test 'user model (with namespace) is created, concern is included' do
         assert_file "app/models/#{namespace_path}.rb" do |model|
           assert_match(/include DeviseTokenAuth::Concerns::User/, model)
         end
@@ -29,11 +29,11 @@ module DeviseTokenAuth
         assert_file 'config/initializers/devise_token_auth.rb'
       end
 
-      test 'migration is created' do
+      test 'migration is created for user model with namespace' do
         assert_migration "db/migrate/devise_token_auth_create_#{table_name}.rb"
       end
 
-      test 'migration file contains rails version' do
+      test 'migration file for user model with namespace contains rails version' do
         if Rails::VERSION::MAJOR >= 5
           assert_migration "db/migrate/devise_token_auth_create_#{table_name}.rb", /#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}/
         else
@@ -112,7 +112,7 @@ module DeviseTokenAuth
         run_generator %W(#{user_class} auth)
       end
 
-      test 'route method is appended to routes file' do
+      test 'route method for user model with namespace is appended to routes file' do
         assert_file 'config/routes.rb' do |routes|
           assert_match(/mount_devise_token_auth_for '#{user_class}', at: 'auth'/, routes)
         end


### PR DESCRIPTION
The current generator did not support namespace models. The patch fixes following issues
1. The migration file not named correctly if namespace is used in models.

` rails g devise_token_auth:install Sprint::V1::Auth::User auth`
      `create  config/initializers/devise_token_auth.rb`
      `**create  db/migrate/devise_token_auth_create_sprint/v1/auth/20180322050951_users.rb**`
      `create  app/models/sprint/v1/auth/user.rb`
      `insert  app/controllers/application_controller.rb`
        `gsub  config/routes.rb`

2.  Class name and table name in migration file is incorrect
```
class DeviseTokenAuthCreateSprint::V1::Auth::Users < ActiveRecord::Migration[5.1]
  def change
    create_table(:sprint/v1/auth/users) do |t|
      ## Required
      t.string :provider, :null => false, :default => "email"
      t.string :uid, :null => false, :default => ""
```
snipped
```
    add_index :sprint/v1/auth/users, :email,                unique: true
    add_index :sprint/v1/auth/users, [:uid, :provider],     unique: true
    add_index :sprint/v1/auth/users, :reset_password_token, unique: true
    add_index :sprint/v1/auth/users, :confirmation_token,   unique: true
    # add_index :sprint/v1/auth/users, :unlock_token,       unique: true
```

3. The model file generated needs a fix
```
    class Sprint::v1::auth::user < ActiveRecord::Base
      # Include default devise modules. Others available are:
      # :confirmable, :lockable, :timeoutable and :omniauthable
      devise :database_authenticatable, :registerable,
             :recoverable, :rememberable, :trackable, :validatable
      include DeviseTokenAuth::Concerns::User
    end
```
