### PR TITLE
Fix broken stubbed method expectation

### DIFF
--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'mocha/test_unit'
+require 'mocha/minitest'
 
 #  was the web request successful?
 #  was the user redirected to the right page?
@@ -70,7 +70,10 @@ class OmniauthTest < ActionDispatch::IntegrationTest
     end
 
     test 'sign_in was called' do
-      User.any_instance.expects(:sign_in)
+      DeviseTokenAuth::OmniauthCallbacksController.any_instance\
+        .expects(:sign_in).with(
+          :user, instance_of(User), has_entries(store: false, bypass: false)
+        )
       get_success
     end
 


### PR DESCRIPTION
 - Update file to require correct Mocha lib for MiniTest (instead of
   Test::Unit). Using the wrong lib previously, meant that Mocha was
   never verifying the stubbed method, and the test passed
   (erroneously).

 - Update test to expect the correct method call for sign_in.

Resolves #1137 (which was exposed by the merge of #1134).