### PR TITLE
Moved to fallback instance variables in `set_user_by_token`

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -17,10 +17,10 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     @used_auth_by_token = true
 
     # initialize instance variables
-    @client_id = nil
-    @resource = nil
-    @token = nil
-    @is_batch_request = nil
+    @client_id ||= nil
+    @resource ||= nil
+    @token ||= nil
+    @is_batch_request ||= nil
   end
 
   def ensure_pristine_resource


### PR DESCRIPTION
As requested in https://github.com/lynndylanhurley/devise_token_auth/issues/1159#issuecomment-387895270, we'd like to fallback our instance variables for `set_user_by_token`. In this PR:

- Moved to fallback instance variables in `set_user_by_token`