### PR TITLE
Update FAQ method for using DeviseTokenAuth alongside Devise

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,6 +66,11 @@ class ApplicationController < ActionController::Base
 end
 ~~~
 
+#### config/initializers/devise_token_auth.rb
+Keep the `enable_standard_devise_support` configuration commented out or set to `false`.
+~~~ruby
+# config.enable_standard_devise_support = false
+~~~
 
 ### Why are the `new` routes included if this gem doesn't use them?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,7 +33,7 @@ end
 
 Some users have been experiencing issues with using this gem alongside standard Devise, with the `config.enable_standard_devise_support = true` method.
 
-Another method suggested by [jotolo](https://github.com/jotolois) is to have separate child `application_controller.rb` files that use either DeviseTokenAuth or standard Devise, which all inherit from a base `application_controller.rb` file. For example, you could have an `api/v1/application_controller.rb` file for the API of your app (which would use Devise Token Auth), and a `admin/application_controller.rb` file for the full stack part of your app (using standard Devise). The idea is to redirect each flow in your application to the appropriate child `application_controller.rb` file. Example code below:
+Another method suggested by [jotolo](https://github.com/jotolo) is to have separate child `application_controller.rb` files that use either DeviseTokenAuth or standard Devise, which all inherit from a base `application_controller.rb` file. For example, you could have an `api/v1/application_controller.rb` file for the API of your app (which would use Devise Token Auth), and a `admin/application_controller.rb` file for the full stack part of your app (using standard Devise). The idea is to redirect each flow in your application to the appropriate child `application_controller.rb` file. Example code below:
 
 #### controllers/api/v1/application_controller.rb
 Child application controller for your API, using DeviseTokenAuth.


### PR DESCRIPTION
- Several users have been experiencing problems using DeviseTokenAuth alongside Devise.
  - The current proposed method in the docs, is to use `config.enable_standard_devise_support = true`. This isn't working for some, and it's noted as a "highly experimental" feature in the initializer. 
  - https://github.com/lynndylanhurley/devise_token_auth/issues/120#issuecomment-300178663

- This new method example was given by [jotolo](https://github.com/jotolo), and it seems like a good approach to have in the FAQ docs. It's the most updated solution in this this thread on using Devise alongside DeviseTokenAuth: https://github.com/lynndylanhurley/devise_token_auth/issues/120#issuecomment-300178663

