### PR TITLE
Update gitbook docs link

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+---
+root: ./
+structure:
+  readme: ./docs/installation.md
+  summary: SUMMARY.md

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then install the gem using bundle:
 bundle install
 ~~~
 
-## [Docs](https://maicolben.gitbooks.io/devise-token-auth/content/docs/config/)
+## [Docs](https://devise-token-auth.gitbook.io/devise-token-auth)
 
 ## Need help?
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,18 +1,13 @@
 # Summary
 
-* Introduction
-  * [Installation](README.md#installation)  
-  * [Need help?](README.md#need-help)
-  * [Live demos](README.md#live-demos)
-* Configuration
-  * [Introduction](docs/config/README.md)
+* [Installation](docs/installation.md)
+* [Configuration](docs/config/README.md)
   * [Initializer Settings](docs/config/initialization.md)
   * [OmniAuth](docs/config/omniauth.md)
   * [Email Authentication](docs/config/email_auth.md)
   * [Customizing Devise Verbiage](docs/config/devise.md)
   * [Cross Origin Requests (CORS)](docs/config/cors.md)
-* Usage
-  * [Introduction](docs/usage/README.md)
+* [Usage](docs/usage/README.md)
   * [Mounting Routes](docs/usage/routes.md)
   * [Controller Integration](docs/usage/controller_methods.md)
   * [Model Integration](docs/usage/model_concerns.md)

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -39,5 +39,5 @@ You may also need to configure the following items:
 
 * **OmniAuth providers** when using 3rd party oauth2 authentication. [Read more](omniauth.md).
 * **Cross Origin Request Settings** when using cross-domain clients. [Read more](cors.md).
-* **Email** when using email registration. [Read more](email-auth.md).
+* **Email** when using email registration. [Read more](email_auth.md).
 * **Multiple model support** may require additional steps. [Read more](/docs/usage/multiple_models.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,13 @@
+## Installation
+
+Add the following to your `Gemfile`:
+
+~~~ruby
+gem 'devise_token_auth'
+~~~
+
+Then install the gem using bundle:
+
+~~~bash
+bundle install
+~~~

--- a/docs/security.md
+++ b/docs/security.md
@@ -3,7 +3,7 @@
 This gem takes the following steps to ensure security.
 
 This gem uses auth tokens that are:
-* [changed after every request](#about-token-management) (can be [turned off](https://github.com/lynndylanhurley/devise_token_auth/#initializer-settings)),
+* [changed after every request](/docs/conceptual.md#about-token-management) (can be [turned off](https://github.com/lynndylanhurley/devise_token_auth/#initializer-settings)),
 * [of cryptographic strength](https://ruby-doc.org/stdlib-2.1.0/libdoc/securerandom/rdoc/SecureRandom.html),
 * hashed using [BCrypt](https://github.com/codahale/bcrypt-ruby) (not stored in plain-text),
 * securely compared (to protect against timing attacks),

--- a/docs/usage/testing.md
+++ b/docs/usage/testing.md
@@ -65,9 +65,9 @@ describe 'Whether access is ocurring properly', type: :request do
       login
       auth_params = get_auth_params_from_login_response_headers(response).tap do |h|
         h.each do |k, _v|
-                                                                      if k == 'access-token'
-                                                                        h[k] = '123'
-                                                                      end end
+          if k == 'access-token'
+            h[k] = '123'
+          end end
       end
       new_client = FactoryBot.create(:client)
       get api_find_client_by_name_path(new_client.name), headers: auth_params
@@ -125,7 +125,7 @@ end
 
 ```
 
-### (b) How to create an authorisation header from Scratch
+### (b) How to create an authorization header from Scratch
 
 ```ruby
 require 'rails_helper'


### PR DESCRIPTION
[Preview](https://maicolben.gitbook.io/devise-token-auth/v/update_doc_link/)

The new gitbook overhaul doesn't like the readme badges, so I had to create a new page for the initial page of the docs that's the installation