### PR TITLE
Add missing SimpleCov configurations

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-SimpleCov.start do
+SimpleCov.start 'rails' do
   add_filter ['.bundle', 'test', 'config']
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-
-SimpleCov.start 'rails'
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+SimpleCov.start do
+  add_filter ['.bundle', 'test', 'config']
+end
 
 ENV['RAILS_ENV'] = 'test'
 


### PR DESCRIPTION
I just finished the `SimpleCov` integration.

**Old report**:
![screen shot 2018-06-19 at 1 13 02 am](https://user-images.githubusercontent.com/1292556/41576471-f5098d36-735d-11e8-9e00-d6c887f124ea.png)

**New report**:
![screen shot 2018-06-19 at 1 17 42 am](https://user-images.githubusercontent.com/1292556/41576591-965a1f20-735e-11e8-86d8-fdf0d07a3e82.png)



