### PR TITLE
Disable email uniqueness validation

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -9,7 +9,7 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
     validates_presence_of :uid, unless: :email_provider?
 
     # only validate unique emails among email registration users
-    validates :email, uniqueness: { scope: :provider }, on: :create, if: :email_provider?
+    validates :email, uniqueness: { scope: :provider }, on: :create, if: :validate_email_uniqueness?
 
     # keep uid in sync with email
     before_save :sync_uid
@@ -20,6 +20,10 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
 
   def email_provider?
     provider == 'email'
+  end
+
+  def validate_email_uniqueness?
+    email_provider?
   end
 
   def sync_uid

--- a/test/dummy/app/models/tenant_user.rb
+++ b/test/dummy/app/models/tenant_user.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class TenantUser < ActiveRecord::Base
+  # Include default devise modules.
+  devise :database_authenticatable, :registerable
+  include DeviseTokenAuth::Concerns::User
+
+  # Override default email validation and handle the tenant field
+  validates :email, uniqueness: { scope: [:tenant, :provider] }, on: :create
+
+  def validate_email_uniqueness?
+    false
+  end
+end

--- a/test/dummy/db/migrate/20180627090309_device_token_auth_create_tenant_users.rb
+++ b/test/dummy/db/migrate/20180627090309_device_token_auth_create_tenant_users.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+include MigrationDatabaseHelper
+
+class DeviceTokenAuthCreateTenantUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table(:tenant_users) do |t|
+      ## Required
+      t.string :provider, :null => false
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## User Info
+      t.string :name
+      t.string :nickname
+      t.string :image
+      t.string :email
+
+      t.string :tenant
+
+      ## Tokens
+      if json_supported_database?
+        t.json :tokens
+      else
+        t.text :tokens
+      end
+
+      t.timestamps
+    end
+
+    add_index :tenant_users, :email
+    add_index :tenant_users, [:tenant, :uid, :provider],     :unique => true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160629184441) do
+ActiveRecord::Schema.define(version: 20180627090309) do
 
   create_table "evil_users", force: :cascade do |t|
     t.string "email"
@@ -165,6 +165,22 @@ ActiveRecord::Schema.define(version: 20160629184441) do
     t.index ["email"], name: "index_scoped_users_on_email"
     t.index ["reset_password_token"], name: "index_scoped_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_scoped_users_on_uid_and_provider", unique: true
+  end
+
+  create_table "tenant_users", force: :cascade do |t|
+    t.string "provider", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.string "tenant"
+    t.text "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_tenant_users_on_email"
+    t.index ["tenant", "uid", "provider"], name: "index_tenant_users_on_tenant_and_uid_and_provider", unique: true
   end
 
   create_table "unconfirmable_users", force: :cascade do |t|

--- a/test/models/tenant_user_test.rb
+++ b/test/models/tenant_user_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TenantUserTest < ActiveSupport::TestCase
+  describe TenantUser do
+    before do
+      @password    = Faker::Internet.password(10, 20)
+      @email       = Faker::Internet.email
+      @success_url = Faker::Internet.url
+      @resource    = TenantUser.new()
+    end
+
+    describe 'email uniqueness' do
+      test 'model should not save if email is taken within the same tenant' do
+        provider = 'email'
+
+        TenantUser.create(
+          email: @email,
+          provider: provider,
+          password: @password,
+          password_confirmation: @password,
+          tenant: 'tenant1'
+        )
+
+        @resource.email                 = @email
+        @resource.provider              = provider
+        @resource.password              = @password
+        @resource.password_confirmation = @password
+        @resource.tenant                = 'tenant1'
+
+        refute @resource.save
+        assert @resource.errors.messages[:email] == [I18n.t('errors.messages.taken')]
+        assert @resource.errors.messages[:email].none? { |e| e =~ /translation missing/ }
+      end
+
+      test 'model should save if email is not taken within the same tenant' do
+        provider = 'email'
+
+        TenantUser.create(
+          email: @email,
+          provider: provider,
+          password: @password,
+          password_confirmation: @password,
+          tenant: 'tenant1'
+        )
+
+        @resource.email                 = @email
+        @resource.provider              = provider
+        @resource.password              = @password
+        @resource.password_confirmation = @password
+        @resource.tenant                = 'tenant2'
+
+        assert @resource.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows a model to disable the default uniqueness validation of email, in order to handle it in a custom way. That's needed if you want to run a multi-tenant setup, which is also how the testing of this change is done.