### PR TITLE
Optimize resource valid check after set the headers

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -24,7 +24,7 @@ module DeviseTokenAuth
       if @resource && valid_params?(field, q_value) && (!@resource.respond_to?(:active_for_authentication?) || @resource.active_for_authentication?)
         valid_password = @resource.valid_password?(resource_params[:password])
         if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
-         return render_create_error_bad_credentials
+          return render_create_error_bad_credentials
         end
         @client_id, @token = @resource.create_token
         @resource.save

--- a/lib/devise_token_auth/errors.rb
+++ b/lib/devise_token_auth/errors.rb
@@ -3,5 +3,6 @@
 module DeviseTokenAuth
   module Errors
     class NoResourceDefinedError < StandardError; end
+    class InvalidModel < StandardError; end
   end
 end

--- a/test/controllers/devise_token_auth/token_validations_controller_test.rb
+++ b/test/controllers/devise_token_auth/token_validations_controller_test.rb
@@ -47,6 +47,19 @@ class DeviseTokenAuth::TokenValidationsControllerTest < ActionDispatch::Integrat
       end
     end
 
+    describe 'with invalid user' do
+      before do
+        @resource.update_column :email, 'invalid'
+      end
+
+      test 'request should raise invalid model error' do
+        error = assert_raises DeviseTokenAuth::Errors::InvalidModel do
+          get '/auth/validate_token', params: {}, headers: @auth_headers
+        end
+        assert_equal(error.message, "Cannot set auth token in invalid model. Errors: [\"Email is not an email\"]")
+      end
+    end
+
     describe 'failure' do
       before do
         get '/api/v1/auth/validate_token',


### PR DESCRIPTION
Resolves #1160

In case `change_headers_on_each_request` is disabled: this will improve and prevent no-tokens sent if the user is invalid.

In case `change_headers_on_each_request` is enabled: this will throw an error if the user is invalid even after loading from DB (password controller and other user's controllers needs to send errors to the fronted), if this happens, it means the user left the model in a valid state and it's a bug of the developer's application.