### PR TITLE
Add raise: false to skip_after_action :update_auth_header

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -3,7 +3,7 @@
 module DeviseTokenAuth
   class PasswordsController < DeviseTokenAuth::ApplicationController
     before_action :set_user_by_token, only: [:update]
-    skip_after_action :update_auth_header, only: [:create, :edit]
+    skip_after_action :update_auth_header, only: [:create, :edit], raise: false
 
     # this action is responsible for generating password reset tokens and
     # sending emails

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -5,7 +5,7 @@ module DeviseTokenAuth
     before_action :set_user_by_token, only: [:destroy, :update]
     before_action :validate_sign_up_params, only: :create
     before_action :validate_account_update_params, only: :update
-    skip_after_action :update_auth_header, only: [:create, :destroy]
+    skip_after_action :update_auth_header, only: [:create, :destroy], raise: false
 
     def create
       build_resource


### PR DESCRIPTION
My application has a controller that inherits from
DeviseTokenAuth:PasswordsController (for internal reasons).
When updating to Rails 5, I am getting the following error:

"After process_action callback :update_auth_header has not been defined"

Due to Rails 5 ActiveSupport::Callbacks#skip_callback now raising an
ArgumentError in case an unrecognized callback is undefined.

Rails 5 will raise the exception
https://github.com/rails/rails/blob/6dfab475ca230dfcad7a603483431c8e7a8f908e/activesupport/lib/active_support/callbacks.rb#L634

A solution is then to add the option raise: false, to the
skip_after_action :update_auth_header