### PR TITLE
chore(deps): expand devise to allow < 4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ PATH
   remote: .
   specs:
     devise_token_auth (1.0.0.rc1)
-      devise (> 3.5.2, < 4.5)
+      devise (> 3.5.2, < 4.6)
       rails (< 6)
 
 GEM
@@ -96,7 +96,7 @@ GEM
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
-    devise (4.4.3)
+    devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -159,7 +159,7 @@ GEM
       mini_mime (>= 0.1.1)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     minitest-focus (1.1.2)
@@ -329,4 +329,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files.reject! { |file| file.match(/[.log|.sqlite3]$/) }
 
   s.add_dependency 'rails', '< 6'
-  s.add_dependency 'devise', '> 3.5.2', '< 4.5'
+  s.add_dependency 'devise', '> 3.5.2', '< 4.6'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'sqlite3', '~> 1.3'


### PR DESCRIPTION
Devise 4.5.0 was released 6 days ago. Doesn't seem to break anything, but more thorough testing might be necessary.