### PR TITLE
Reset passwords stay valid until the password is reset

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -44,7 +44,7 @@ module DeviseTokenAuth
     # this is where users arrive after visiting the password reset confirmation link
     def edit
       # if a user is not found, return nil
-      @resource = with_reset_password_token(resource_params[:reset_password_token])
+      @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
 
       if @resource && @resource.reset_password_period_valid?
         client_id, token = @resource.create_token
@@ -176,13 +176,6 @@ module DeviseTokenAuth
 
     def password_resource_params
       params.permit(*params_for_resource(:account_update))
-    end
-
-    def with_reset_password_token token
-      recoverable = resource_class.with_reset_password_token(token)
-
-      recoverable.reset_password_token = token if recoverable && recoverable.reset_password_token.present?
-      recoverable
     end
 
     def render_not_found_error

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -235,14 +235,14 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
               assert_equal Devise.token_generator.digest(self, :reset_password_token, @mail_reset_token), @resource.reset_password_token
             end
 
-            test 'reset_password_token should be rewritten by origin mail_reset_token' do
+            test 'reset_password_token should not be rewritten by origin mail_reset_token' do
               get :edit, params: {
                 reset_password_token: @mail_reset_token,
                 redirect_url: @mail_redirect_url
               }
               @resource.reload
 
-              assert_equal @mail_reset_token, @resource.reset_password_token
+              assert_equal Devise.token_generator.digest(self, :reset_password_token, @mail_reset_token), @resource.reset_password_token
             end
 
             test 'response should return success status' do
@@ -254,26 +254,6 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
               assert_equal 302, response.status
             end
 
-            test 'reset_password_token should be valid only one first time' do
-              get :edit, params: {
-                reset_password_token: @mail_reset_token,
-                redirect_url: @mail_redirect_url
-              }
-
-              @resource.reload
-              assert_equal @mail_reset_token, @resource.reset_password_token
-
-              assert_raises(ActionController::RoutingError) {
-                get :edit, params: {
-                  reset_password_token: @mail_reset_token,
-                  redirect_url: @mail_redirect_url
-                }
-              }
-
-              @resource.reload
-              assert_equal @mail_reset_token, @resource.reset_password_token
-            end
-
             test 'reset_password_sent_at should be valid' do
               assert_equal @resource.reset_password_period_valid?, true
 
@@ -283,7 +263,7 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
               }
 
               @resource.reload
-              assert_equal @mail_reset_token, @resource.reset_password_token
+              assert_equal Devise.token_generator.digest(self, :reset_password_token, @mail_reset_token), @resource.reset_password_token
             end
 
             test 'reset_password_sent_at should be expired' do

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -489,6 +489,10 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
           test 'new password should authenticate user' do
             assert @resource.valid_password?(@new_password)
           end
+
+          test 'reset_password_token should be removed' do
+            assert_nil @resource.reset_password_token
+          end
         end
 
         describe 'password mismatch error' do


### PR DESCRIPTION
Or until the validity period has expired. This reverts an issue caused by #1008 where users who follow the password reset link from an email multiple times, or those who have anti spam filters which check links, are unable to reset their passwords.