### PR TITLE
Add required_ruby_version

### DIFF
--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
   s.test_files.reject! { |file| file.match(/[.log|.sqlite3]$/) }
 
+  s.required_ruby_version = ">= 2.2.0"
+
   s.add_dependency 'rails', '< 6'
   s.add_dependency 'devise', '> 3.5.2', '< 4.6'
 


### PR DESCRIPTION
Because used hash literal that symbol key followed by a colon.

e.g.
https://github.com/masatooba/devise_token_auth/blob/add-required-ruby-version/lib/devise_token_auth/engine.rb#L41

The literal is not supported before 2.2.0.
Even if it is a version earlier than 2.2.0 you can install it, so when trying to use, raise error.