### PR TITLE
Add rails lowest version to gemspec

### DIFF
--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2.0"
 
-  s.add_dependency 'rails', '< 6'
+  s.add_dependency 'rails', '>= 4.2.0', '< 6'
   s.add_dependency 'devise', '> 3.5.2', '< 4.6'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
This gem uses ActionDispatch::Routing::Mapper::Scope,
but ActionDispatch::Routing::Mapper::Scope exists from rais `4.2` or above.
https://github.com/rails/rails/commit/dc3f25c8a5aa64de9225f11498a389a2d31e880a#diff-46876897330259072a679792c5f45f99R1896

This gem does not work before rails `4.2` .