### PR TITLE
Removed ensure pristine error due to not being used

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ bundle exec guard
 
 Guard will re-run each test suite when changes are made to its corresponding files.
 
-To run **just one test**: Flavio Castelli blogged about [how to execute a single unit test (or even a single test method)](https://flavio.castelli.me/2010/05/28/rails_execute_single_test/) instead of running the complete unit test suite.
+To run **just one test**: Flavio Castelli blogged about [how to execute a single unit test (or even a single test method)](https://flavio.castelli.me/2010/05/28/how-to-run-a-single-rails-unit-test/) instead of running the complete unit test suite.
 
 To run the full **test suite** with the guard and the [appraisal](https://github.com/thoughtbot/appraisal) against `ActiveRecord`:
 


### PR DESCRIPTION
Resolves #1135

Trying to fix this issue, I realized that wasn't ever entering to the `if @resource.changed?` because now we are reloading the resource with #1188, but is that correct? we might lose changes! Well the thing is that we don't make changes to the resource between the beginning of `update_auth_header` and the call of `refresh_headers`, we can have changes between the developer's controller action and the call of `update_auth_header`  but that's bad, you shouldn't leave the model without saving.

`ensure_pristine_resource` was added in #1049 to suppress warnings, but now without it, we don't have them anymore due to the `reload` mentioned previously.