### PR TITLE
Bump version 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,9 @@ GIT
 PATH
   remote: .
   specs:
-    devise_token_auth (1.0.0.rc1)
+    devise_token_auth (1.0.0)
       devise (> 3.5.2, < 4.6)
-      rails (< 6)
+      rails (>= 4.2.0, < 6)
 
 GEM
   remote: https://rubygems.org/
@@ -155,7 +155,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     metaclass (0.0.4)
     method_source (0.8.2)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Please use [StackOverflow](https://stackoverflow.com/questions/tagged/devise-tok
 
 Please open GitHub issues for bugs and enhancements only, not general help requests. Please search previous issues (and Google and StackOverflow) before creating a new issue.
 
-Please read the [ISSUE_TEMPLATE.md] before posting issues.
+Please read the [issue template](https://github.com/lynndylanhurley/devise_token_auth/blob/master/.github/ISSUE_TEMPLATE.md) before posting issues.
 
 ## [FAQ](docs/faq.md)
 

--- a/lib/devise_token_auth/version.rb
+++ b/lib/devise_token_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeviseTokenAuth
-  VERSION = '1.0.0.rc1'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
As I don't see any critical bug, I will just push the current master to 1.0.0. Mongo and next features will come to 1.1.0. 