### PR TITLE
Scope the EmailValidator to the DeviseTokenAuth module; add Solidus/Spree usage note to faq

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -5,7 +5,7 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
 
   included do
     validates :email, presence: true,if: :email_provider?
-    validates :email, email: true, allow_nil: true, allow_blank: true, if: :email_provider?
+    validates :email, 'devise_token_auth/email' => true, allow_nil: true, allow_blank: true, if: :email_provider?
     validates_presence_of :uid, unless: :email_provider?
 
     # only validate unique emails among email registration users

--- a/app/validators/devise_token_auth/email_validator.rb
+++ b/app/validators/devise_token_auth/email_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EmailValidator < ActiveModel::EachValidator
+class DeviseTokenAuth::EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
       record.errors[attribute] << email_invalid_message

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -100,6 +100,10 @@ end
 
 You may be interested in [GrapeTokenAuth](https://github.com/mcordell/grape_token_auth) or [GrapeDeviseTokenAuth](https://github.com/mcordell/grape_devise_token_auth).
 
+### How can I use this gem with Solidus/Spree?
+
+You may be interested in [solidus_devise_token_auth](https://github.com/skycocker/solidus_devise_token_auth).
+
 ### What's the reset password flow?
 
 This is the overall workflow for a User to reset their password:


### PR DESCRIPTION
I spent some weeks on integrating devise_token_auth into solidus and I guess some people might want to do the same one day.

Also, the EmailValidator class conflicted with solidus/spree one, so I scoped it into a module.