### PR TITLE
Fixed a reset password message in Japanese locales.

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -34,7 +34,7 @@ ja:
         confirm_link_msg: "下記のリンクからアカウントを有効化できます:"
         confirm_account_link: "アカウントを有効化する"
       reset_password_instructions:
-        request_reset_link_msg: "パスワード変更のリクエストが送信されました。下記のリンクからパスワードの変更をできます。"
+        request_reset_link_msg: "パスワード変更のリクエストが送信されました。下記のリンクからパスワードの変更ができます。"
         password_change_link: "パスワードを変更する"
         ignore_mail_msg: "もしこの内容に覚えがない場合は、このメールを無視してください。"
         no_changes_msg: "上記のリンクにアクセスして新しいパスワードを作成するまで、現在のパスワードは変更されません。"


### PR DESCRIPTION
Japanese locales has a small problem in devise_token_auth/config/locales/ja.yml

This 'request_reset_link_msg' is "下記のリンクからパスワードの変更  'を'  できます" right now.

But this message is slightly strange for Japanese.

In this case, "下記のリンクからパスワードの変更  'が'  できます". is natural.

This is very small problem,
But this message could be seen by users who use the web service.

And, Japanese are often suspicious of that web service if some messages has strange Japanese grammar.

ex.
"Was this web service developed by a dishonest dealer...?? 
I don't want to use that service, because 
there is a possibility to get some computer virus from that service...."

So, I make a suggestion fixing this small grammatical mistakes.