### PR TITLE
Delete namespece and fix file name change to prevent override behavior of the default email validator

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -5,7 +5,7 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
 
   included do
     validates :email, presence: true,if: :email_provider?
-    validates :email, 'devise_token_auth/email' => true, allow_nil: true, allow_blank: true, if: :email_provider?
+    validates :email, :devise_token_auth_email => true, allow_nil: true, allow_blank: true, if: :email_provider?
     validates_presence_of :uid, unless: :email_provider?
 
     # only validate unique emails among email registration users

--- a/app/validators/devise_token_auth_email_validator.rb
+++ b/app/validators/devise_token_auth_email_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeviseTokenAuth::EmailValidator < ActiveModel::EachValidator
+class DeviseTokenAuthEmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
       record.errors[attribute] << email_invalid_message


### PR DESCRIPTION
I fixed DeviseTokenAuth::EmailValidator overrides the behavior of rails email validator.