### PR TITLE
Tokens serialization

### DIFF
--- a/app/models/devise_token_auth/concerns/active_record_support.rb
+++ b/app/models/devise_token_auth/concerns/active_record_support.rb
@@ -1,12 +1,10 @@
+require_relative 'tokens_serialization'
+
 module DeviseTokenAuth::Concerns::ActiveRecordSupport
   extend ActiveSupport::Concern
 
   included do
-    serialize :tokens, JSON unless tokens_has_json_column_type?
-
-    # can't set default on text fields in mysql, simulate here instead.
-    after_save :set_empty_token_hash
-    after_initialize :set_empty_token_hash
+    serialize :tokens, DeviseTokenAuth::TokensSerialization
   end
 
   class_methods do
@@ -14,21 +12,5 @@ module DeviseTokenAuth::Concerns::ActiveRecordSupport
     def dta_find_by(attrs = {})
       find_by(attrs)
     end
-
-    protected
-
-    def tokens_has_json_column_type?
-      database_exists? && table_exists? && columns_hash['tokens'] && columns_hash['tokens'].type.in?([:json, :jsonb])
-    end
-
-    def database_exists?
-      ActiveRecord::Base.connection_pool.with_connection { |con| con.active? } rescue false
-    end
-  end
-
-  protected
-
-  def set_empty_token_hash
-    self.tokens ||= {} if has_attribute?(:tokens)
   end
 end

--- a/app/models/devise_token_auth/concerns/tokens_serialization.rb
+++ b/app/models/devise_token_auth/concerns/tokens_serialization.rb
@@ -1,0 +1,19 @@
+module DeviseTokenAuth::TokensSerialization
+  # Serialization hash to json
+  def self.dump(object)
+    object.each_value(&:compact!) unless object.nil?
+    JSON.generate(object)
+  end
+
+  # Deserialization json to hash
+  def self.load(json)
+    case json
+    when String
+      JSON.parse(json)
+    when NilClass
+      {}
+    else
+      json
+    end
+  end
+end

--- a/test/models/concerns/tokens_serialization_test.rb
+++ b/test/models/concerns/tokens_serialization_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+if DEVISE_TOKEN_AUTH_ORM == :active_record
+  describe 'DeviseTokenAuth::TokensSerialization' do
+    let(:ts) { DeviseTokenAuth::TokensSerialization }
+    let(:user) { FactoryBot.create(:user) }
+    let(:tokens) do
+      # Сreate all possible token's attributes combinations
+      user.create_token
+      2.times { user.create_new_auth_token(user.tokens.first[0]) }
+      user.create_new_auth_token
+      user.create_token
+
+      user.tokens
+    end
+    let(:json) { JSON.generate(tokens) }
+
+    it 'is defined' do
+      assert_equal(ts.present?, true)
+      assert_kind_of(Module, ts)
+    end
+
+    describe '.load(json)' do
+      let(:default) { {} }
+
+      it 'is defined' do
+        assert_respond_to(ts, :load)
+      end
+
+      it 'handles nil' do
+        assert_equal(ts.load(nil), default)
+      end
+
+      it 'handles string' do
+        assert_equal(ts.load(json), JSON.parse(json))
+      end
+
+      it 'returns object of undesirable class' do
+        assert_equal(ts.load([]), [])
+      end
+    end
+
+    describe '.dump(object)' do
+      let(:default) { 'null' }
+
+      it 'is defined' do
+        assert_respond_to(ts, :dump)
+      end
+
+      it 'handles nil' do
+        assert_equal(ts.dump(nil), default)
+      end
+
+      it 'handles empty hash' do
+        assert_equal(ts.dump({}), '{}')
+      end
+
+      it 'deserialize tokens' do
+        assert_equal(ts.dump(tokens), json)
+      end
+
+      it 'removes nil values' do
+        new_tokens = tokens.dup
+        new_tokens[new_tokens.first[0]][:kos] = nil
+
+        assert_equal(ts.dump(tokens), ts.dump(new_tokens))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is custom [coder](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize) for tokens column with known object's structure (only Hash). This is based on `JSON` coder with some edge cases (nil, blank string).

`PG` registers `jsonb` as alias type for `json` and uses own [text coder](https://github.com/ged/ruby-pg/blob/b920bb33eaa4797cdfdca8885dd56dbd04d6b8ea/lib/pg/basic_type_mapping.rb#L218-L219) where also uses `JSON` coder and few other date/time formats for [encoding](https://github.com/ged/ruby-pg/blob/1d9883d06bdf5413880f20bbb445720dedebd736/lib/pg/text_encoder.rb)/[decoding](https://github.com/ged/ruby-pg/blob/1d9883d06bdf5413880f20bbb445720dedebd736/lib/pg/text_decoder.rb).

Should help to serialize/deserialize tokens properly.

This should fix:
#1079 #121
and may:
#1240 #1224 

Need help testing the PR before it will be merged.

**UPDATE**

- Updated `dump` method.
- Deleted code from `load` method that recognize case when json is blank string (it is unlikely case).