### PR TITLE
DeviseTokenAuth::Url.generate should accept relate path

### DIFF
--- a/lib/devise_token_auth/url.rb
+++ b/lib/devise_token_auth/url.rb
@@ -4,15 +4,10 @@ module DeviseTokenAuth::Url
 
   def self.generate(url, params = {})
     uri = URI(url)
+    query_params = Hash[URI.decode_www_form(uri.query || '')].merge(params)
+    uri.query = URI.encode_www_form(query_params)
 
-    res = "#{uri.scheme}://#{uri.host}"
-    res += ":#{uri.port}" if (uri.port && uri.port != 80 && uri.port != 443)
-    res += uri.path.to_s if uri.path
-    query = [uri.query, params.to_query].reject(&:blank?).join('&')
-    res += "?#{query}"
-    res += "##{uri.fragment}" if uri.fragment
-
-    res
+    uri.to_s
   end
 
   def self.whitelisted?(url)

--- a/test/lib/devise_token_auth/url_test.rb
+++ b/test/lib/devise_token_auth/url_test.rb
@@ -10,6 +10,12 @@ class DeviseTokenAuth::UrlTest < ActiveSupport::TestCase
       assert_equal DeviseTokenAuth::Url.send(:generate, url, params), 'http://example.com?client_id=123#fragment'
     end
 
+    test 'relative path should be returned if url is relative' do
+      params = { client_id: 123 }
+      url = '/foobar'
+      assert_equal DeviseTokenAuth::Url.send(:generate, url, params), '/foobar?client_id=123'
+    end
+
     describe 'with existing query params' do
       test 'should preserve existing query params' do
         url = 'http://example.com?a=1'


### PR DESCRIPTION
When a relative url or empty string is passed to `DeviseTokenAuth::Url.generate`, it should parse and return the same relative url back.