### PR TITLE
User#send_reset_password_instructions redirect_url not set as default if blank

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -69,6 +69,7 @@ module DeviseTokenAuth::Concerns::User
 
       # fall back to "default" config name
       opts[:client_config] ||= 'default'
+      opts[:redirect_url] ||= DeviseTokenAuth.default_password_reset_url
 
       send_devise_notification(:reset_password_instructions, token, opts)
       token


### PR DESCRIPTION
`redirect_url` should be set to `DeviseTokenAuth.default_password_reset_url` if not present in the options