### PR TITLE
Update Angular-Token README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Also, it maintains a session for each client/device, so you can have as many ses
 
 * Seamless integration with:
   * [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) for [AngularJS](https://github.com/angular/angular.js)
-  * [Angular2-Token](https://github.com/neroniaky/angular2-token) for [Angular2](https://github.com/angular/angular)
+  * [Angular-Token](https://github.com/neroniaky/angular-token) for [Angular](https://github.com/angular/angular)
   * [redux-token-auth](https://github.com/kylecorbelli/redux-token-auth) for [React with Redux](https://github.com/reactjs/react-redux)
   * [jToker](https://github.com/lynndylanhurley/j-toker) for [jQuery](https://jquery.com/)
 * Oauth2 authentication using [OmniAuth](https://github.com/intridea/omniauth).
@@ -69,7 +69,7 @@ See our [Contribution Guidelines](https://github.com/lynndylanhurley/devise_toke
 
 [Here is a demo](http://ng-token-auth-demo.herokuapp.com/) of this app running with the [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) module and [AngularJS](https://github.com/angular/angular.js).
 
-[Here is a demo](https://angular2-token.herokuapp.com) of this app running with the [Angular2-Token](https://github.com/neroniaky/angular2-token) service and [Angular2](https://github.com/angular/angular).
+[Here is a demo](https://stackblitz.com/github/neroniaky/angular-token) of this app running with the [Angular-Token](https://github.com/neroniaky/angular-token) service and [Angular](https://github.com/angular/angular).
 
 [Here is a demo](https://j-toker-demo.herokuapp.com/) of this app using the [jToker](https://github.com/lynndylanhurley/j-toker) plugin and [React](http://facebook.github.io/react/).
 


### PR DESCRIPTION
This corrects the links for the Angular-Token Repo and demo in the README.

Angular2-Token was renamed to Angular-Token to comply with the guideline published by the Angular team. (Angular 1.x == "AngularJS", Angular 2+ == "Angular")
The demo location was changed from Heroku to Stackblitz.