### PR TITLE
Upgrade gem dependency (Devise)

### DIFF
--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.0"
 
   s.add_dependency 'rails', '>= 4.2.0', '< 6'
-  s.add_dependency 'devise', '> 3.5.2', '< 4.6'
+  s.add_dependency 'devise', '> 3.5.2', '< 4.7'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'sqlite3', '~> 1.3'


### PR DESCRIPTION
Upgrades Devise to allow Rails applications running on Devise v4.6 to use this gem.