### PR TITLE
Convert q_value to_s

### DIFF
--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -6,7 +6,7 @@ module DeviseTokenAuth::Concerns::ResourceFinder
 
   def get_case_insensitive_field_from_resource_params(field)
     # honor Devise configuration for case_insensitive keys
-    q_value = resource_params[field.to_sym]
+    q_value = resource_params[field.to_sym].to_s
 
     if resource_class.case_insensitive_keys.include?(field.to_sym)
       q_value.downcase!


### PR DESCRIPTION
Ensure that `q_value` is a string to call method `downcase!` (line 12) and `strip!`. You can pass for example the email parameter = null with Postman: in this scenario you get 500 `NoMethodError (undefined method `downcase!' for nil:NilClass)`