### PR TITLE
allow devise < 4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ bundler_args: --without development
 rvm:
   - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.5.5
+  - 2.6.2
 
 gemfile:
   - gemfiles/rails_4_2.gemfile
@@ -36,17 +36,17 @@ matrix:
   - rvm: 2.4.5
     gemfile: gemfiles/rails_5_1_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     gemfile: gemfiles/rails_5_2_mongoid_6.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.5.3
+  - rvm: 2.5.5
     gemfile: gemfiles/rails_5_2_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.6.0
+  - rvm: 2.6.2
     gemfile: gemfiles/rails_5_2_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
   - name: Code Climate Test Coverage
-    rmv: 2.5.3
+    rmv: 2.5.5
     env:
       - CC_TEST_REPORTER_ID=44d7688de8e1b567b4af25ec5083c2cc0a355ab911192a7cbefd1ea25b2ffd3d
       - GEMFILE_AR=gemfiles/rails_5_1.gemfile
@@ -70,7 +70,7 @@ matrix:
           ./cc-test-reporter upload-coverage;
         fi
   exclude:
-    - rvm: 2.6.0
+    - rvm: 2.6.2
       gemfile: gemfiles/rails_4_2.gemfile
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,10 @@ matrix:
       gemfile: gemfiles/rails_4_2.gemfile
   fast_finish: true
 
+before_install:
+  - "[[ $BUNDLE_GEMFILE == *rails_4_2* ]] && gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true"
+  - "[[ $BUNDLE_GEMFILE == *rails_4_2* ]] && gem install bundler -v '< 2' || true"
+
 before_script:
   - if [[ $DB == "mysql" ]]; then mysql -e 'create database devise_token_auth_test'; fi
   - if [[ $DB == "postgresql" ]]; then psql -c 'create database devise_token_auth_test' -U postgres; fi

--- a/Appraisals
+++ b/Appraisals
@@ -37,7 +37,6 @@ end
   appraise "rails-#{set[:name]}-mongoid-#{set[:mongoid][0]}" do
     gem 'rails', "~> #{set[:rails]}"
 
-    gem 'sqlite3', '~> 1.3.6'
     gem 'mongoid', "~> #{set[:mongoid]}"
     gem 'mongoid-locker', '~> 1.0'
   end

--- a/Appraisals
+++ b/Appraisals
@@ -30,9 +30,9 @@ end
   { name: '4-2', ruby: '2.3.8', rails: '4.2', mongoid: '5.4' },
   { name: '5-1', ruby: '2.3.8', rails: '5.1', mongoid: '6.4' },
   { name: '5-1', ruby: '2.4.5', rails: '5.1', mongoid: '7.0' },
-  { name: '5-2', ruby: '2.5.3', rails: '5.2', mongoid: '6.4' },
-  { name: '5-2', ruby: '2.5.3', rails: '5.2', mongoid: '7.0' },
-  { name: '5-2', ruby: '2.6.0', rails: '5.2', mongoid: '7.0' }
+  { name: '5-2', ruby: '2.5.5', rails: '5.2', mongoid: '6.4' },
+  { name: '5-2', ruby: '2.5.5', rails: '5.2', mongoid: '7.0' },
+  { name: '5-2', ruby: '2.6.2', rails: '5.2', mongoid: '7.0' }
 ].each do |set|
   appraise "rails-#{set[:name]}-mongoid-#{set[:mongoid][0]}" do
     gem 'rails', "~> #{set[:rails]}"

--- a/Appraisals
+++ b/Appraisals
@@ -6,7 +6,7 @@
   appraise "rails-#{rails[:name]}" do
     gem 'rails', "~> #{rails[:version]}"
 
-    gem 'sqlite3', '~> 1.3'
+    gem 'sqlite3', '~> 1.3.6'
     gem 'mysql2', '~> 0.4.10'
     gem 'pg', '~> 0.21'
   end
@@ -20,7 +20,7 @@ end
   appraise "rails-#{rails[:name]}" do
     gem 'rails', "~> #{rails[:version]}"
 
-    gem 'sqlite3'
+    gem 'sqlite3', '~> 1.3.6'
     gem 'mysql2'
     gem 'pg'
   end
@@ -37,6 +37,7 @@ end
   appraise "rails-#{set[:name]}-mongoid-#{set[:mongoid][0]}" do
     gem 'rails', "~> #{set[:rails]}"
 
+    gem 'sqlite3', '~> 1.3.6'
     gem 'mongoid', "~> #{set[:mongoid]}"
     gem 'mongoid-locker', '~> 1.0'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem 'omniauth-github',        git: 'https://github.com/intridea/omniauth-github'
   gem 'omniauth-google-oauth2', git: 'https://github.com/zquestz/omniauth-google-oauth2'
   gem 'rack-cors', require: 'rack/cors'
-  gem 'sqlite3', '~> 1.3.6'
   gem 'thor'
 
   # testing

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'omniauth-github',        git: 'https://github.com/intridea/omniauth-github'
   gem 'omniauth-google-oauth2', git: 'https://github.com/zquestz/omniauth-google-oauth2'
   gem 'rack-cors', require: 'rack/cors'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'thor'
 
   # testing

--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.0"
 
   s.add_dependency 'rails', '>= 4.2.0', '< 6'
-  s.add_dependency 'devise', '> 3.5.2', '< 4.6'
+  s.add_dependency 'devise', '> 3.5.2', '< 4.7'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'sqlite3', '~> 1.3'

--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'devise', '> 3.5.2', '< 4.7'
 
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'sqlite3', '~> 1.3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'mongoid', '>= 4', '< 8'

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2"
-gem "sqlite3", "~> 1.3"
+gem "sqlite3", "~> 1.3.6"
 gem "mysql2", "~> 0.4.10"
 gem "pg", "~> 0.21"
 

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0"
-gem "sqlite3"
+gem "sqlite3", "~> 1.3.6"
 gem "mysql2"
 gem "pg"
 

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1"
-gem "sqlite3"
+gem "sqlite3", "~> 1.3.6"
 gem "mysql2"
 gem "pg"
 

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2"
-gem "sqlite3"
+gem "sqlite3", "~> 1.3.6"
 gem "mysql2"
 gem "pg"
 


### PR DESCRIPTION
Tests pass and my app works with it, too, but maybe someone with a more complicated setup could test it a little bit more.

Note: I had to explicitly `require 'devise/orm/active_record'` in `config/initializers/devise_token_auth.rb` or else I had some errors about missing method `devise` in my models. Before I didn't had it and everything worked, but maybe now it is required? Not sure if this should be added to `lib/generators/devise_token_auth/templates/devise_token_auth.rb` here, too.

(Devise < 4.6 has a [security issue](https://github.com/plataformatec/devise/issues/4981), so I think it should be updated as fast as possible)