### PR TITLE
Skip token_validations route

### DIFF
--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -56,7 +56,7 @@ module ActionDispatch::Routing
 
         devise_scope mapping_name.to_sym do
           # path to verify token validity
-          get "#{full_path}/validate_token", controller: token_validations_ctrl.to_s, action: 'validate_token'
+          get "#{full_path}/validate_token", controller: token_validations_ctrl.to_s, action: 'validate_token' if !opts[:skip].include?(:token_validations)
 
           # omniauth routes. only define if omniauth is installed and not skipped.
           if defined?(::OmniAuth) && !opts[:skip].include?(:omniauth_callbacks)


### PR DESCRIPTION
I'm not sure if this is a bug.

 I think

```
mount_devise_token_auth_for ..., skip: [:token_validations]
```

should skip to create route of `token_validations#validate_token` .