### PR TITLE
Sign in user after confimation success

### DIFF
--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -63,30 +63,6 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
           end
         end
 
-        describe 'when unauthenticated' do
-          before do
-            sign_out(@new_user)
-            get :show,
-                params: { confirmation_token: @token,
-                          redirect_url: @redirect_url },
-                xhr: true
-            @resource = assigns(:resource)
-          end
-
-          test 'user should now be confirmed' do
-            assert @resource.confirmed?
-          end
-
-          test 'should redirect to success url' do
-            assert_redirected_to(/^#{@redirect_url}/)
-          end
-
-          test 'redirect url does not include token params' do
-            refute @token_params.any? { |param| response.body.include?(param) }
-            assert response.body.include?('account_confirmation_success')
-          end
-        end
-
         describe 'resend confirmation' do
           before do
             post :create,


### PR DESCRIPTION
• Issue: [#1278](https://github.com/lynndylanhurley/devise_token_auth/issues/1278)
• Topic: Bug: Registration broken if multiple users signed in

Digging into the code while trying to tackle this issue, I found a few more:

1) Wrong use of `signed_in?` helper: This helper checks if a user object is signed in. We should use `user_signed_in?` instead.
2) We don't even need to check for signed_in user here: Since this request comes after registration_controller method and the only params that are coming from the generated url are `confirmation_token` and `redirect_url`, there's no way that a user is logged at this point (considering that we are not using cookies to keep the session)
3) confirmation_token generated but not saved: In [this](https://github.com/lynndylanhurley/devise_token_auth/compare/master...GAKINDUSTRIES:enhancement/confirmations_controller_signed_in_users?expand=1#diff-160c1afc120d57b344db17e0b7fc4280R28) line we are generating the token for the user but it's never saved in the database.
I attach the code of `create_token` method:

```Ruby
def create_token(client_id: nil, token: nil, expiry: nil, **token_extras)
    client_id ||= SecureRandom.urlsafe_base64(nil, false)
    token     ||= SecureRandom.urlsafe_base64(nil, false)
    expiry    ||= (Time.zone.now + token_lifespan).to_i

    tokens[client_id] = {
      token: BCrypt::Password.create(token),
      expiry: expiry
    }.merge!(token_extras)

    clean_old_tokens

    [client_id, token, expiry]
  end
```

 Thus, we create the user with a token that can't be used later. We need to save the generated token (`@resource.save!`) to reflect the new token at the database level.

In this PR I removed the logged in conditional and I log in the user (using `store: false` to avoid saving in session) and `save!` the record to update it in the database. I also reorder the methods inside the controller (to keep CRUD order) and fix a small indentation problem.

Note: I removed the test within `unauthenticated context` since it does not make sense anymore.