### PR TITLE
chore(deps): update bcrypt-3.1.13

### DIFF
--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 4.2.0', '< 6'
   s.add_dependency 'devise', '> 3.5.2', '< 4.7'
-  s.add_dependency 'bcrypt', '3.1.12'
+  s.add_dependency 'bcrypt', '3.1.13'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'sqlite3', '~> 1.3.6'


### PR DESCRIPTION
This update includes a bump to the default `cost` from `10` to `12`. Seems that we should support this standard going forward since the `cost` had not changed since initial release in 2007 (?).

see also: https://github.com/lynndylanhurley/devise_token_auth/issues/1301#issuecomment-501396488