### PR TITLE
fix(current_user): revert false return in set_user_by_token when token is not present

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -62,7 +62,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     # ensure we clear the client
     unless @token.present?
       @token.client = nil
-      return false
+      return
     end
 
     # mitigate timing attacks by finding by uid instead of auth token


### PR DESCRIPTION
Some breaking behavior was introduced in https://github.com/lynndylanhurley/devise_token_auth/pull/1085/files#diff-787ec1bd1e5a87dca1d85fa6f8b2f7b3R65 in `set_user_by_token`. Previously, we would return an implicit `nil` if the token was not present (`unless @token ...`), but now we are returning `false` in this case. This appears to be based on the refactoring of a subsequent (but completely inaccessible and confusing) call to `return false unless @token`. 

The issue became immediately apparent after taking the referenced commit and encountering application logic to check various `current_user` state with elvis operators (eg - `current_user&.can_view_something?`) which all blew up with the following:

```
NoMethodError: undefined method `can_view_something?' for false:FalseClass
```

This PR reverts to the previous behavior.