### PR TITLE
updates: use update instead of update_attributes

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -92,7 +92,7 @@ module DeviseTokenAuth
     def resource_update_method
       allow_password_change = recoverable_enabled? && @resource.allow_password_change == true
       if DeviseTokenAuth.check_current_password_before_update == false || allow_password_change
-        'update_attributes'
+        'update'
       else
         'update_with_password'
       end

--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -181,7 +181,7 @@ module DeviseTokenAuth
       elsif account_update_params.key?(:current_password)
         'update_with_password'
       else
-        'update_attributes'
+        'update'
       end
     end
 

--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -321,8 +321,8 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
           assert @resource.tokens.count > 1
 
           # password changed from new device
-          @resource.update_attributes(password: 'newsecret123',
-                                      password_confirmation: 'newsecret123')
+          @resource.update(password: 'newsecret123',
+                           password_confirmation: 'newsecret123')
 
           get '/demo/members_only',
               params: {},

--- a/test/dummy/app/controllers/overrides/registrations_controller.rb
+++ b/test/dummy/app/controllers/overrides/registrations_controller.rb
@@ -6,7 +6,7 @@ module Overrides
 
     def update
       if @resource
-        if @resource.update_attributes(account_update_params)
+        if @resource.update(account_update_params)
           render json: {
             status: 'success',
             data:   @resource.as_json,


### PR DESCRIPTION
Rails 6 deprecates `update_attributes(!)` (see [ActiveRecord Deprecations](https://edgeguides.rubyonrails.org/6_0_release_notes.html#active-record-deprecations)). This pull request remove usages of `update_attributes(!)` in favor of `update(!)`.