### PR TITLE
Fix "manage the tokens" broken link in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ### I have missing headers or issues with batch requests
 
-Try disabling `change_headers_on_each_request`, it's a nice to have security enhancement but not crucial. If you are curious, you can check how we [manage the tokens and batch requests](docs/conceptual.md)
+Try disabling `change_headers_on_each_request`, it's a nice to have security enhancement but not crucial. If you are curious, you can check how we [manage the tokens and batch requests](conceptual.md)
 
 ### Can I use this gem alongside standard Devise?
 


### PR DESCRIPTION
Redundent `/docs/` in "manage the tokens and batch requests" link.