### PR TITLE
Confirmations controller rendering methods added

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -34,14 +34,27 @@ module DeviseTokenAuth
 
       @resource = resource_class.dta_find_by(uid: params[:email].downcase, provider: provider)
 
-      return head :not_found unless @resource
+      return render_not_found_error unless @resource
 
       @resource.send_confirmation_instructions({
         redirect_url: redirect_url,
         client_config: params[:config_name]
       })
 
-      head :ok
+      return render_create_success
+    end
+
+    protected
+
+    def render_create_success
+      render json: {
+          success: true,
+          message: I18n.t('devise_token_auth.confirmations.sended', email: @email)
+      }
+    end
+
+    def render_not_found_error
+      render_error(404, I18n.t('devise_token_auth.confirmations.user_not_found', email: @email))
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,10 @@ en:
       missing_email: "You must provide an email address."
       sended: "An email has been sent to '%{email}' containing instructions for unlocking your account."
       user_not_found: "Unable to find user with email '%{email}'."
+    confirmations:
+      sended: "An email has been sent to '%{email}' containing instructions for confirming your account."
+      user_not_found: "Unable to find user with email '%{email}'."
+
   errors:
     messages:
       validate_sign_up_params: "Please submit proper sign up data in request body."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
     confirmations:
       sended: "An email has been sent to '%{email}' containing instructions for confirming your account."
       user_not_found: "Unable to find user with email '%{email}'."
+      missing_email: "You must provide an email address."
 
   errors:
     messages:

--- a/docs/usage/overrides.md
+++ b/docs/usage/overrides.md
@@ -75,6 +75,7 @@ To customize json rendering, implement the following protected controller method
 * render_validate_token_error
 
 ### Confirmations Controller
+* render_create_error_missing_email
 * render_create_success
 * render_not_found_error
 

--- a/docs/usage/overrides.md
+++ b/docs/usage/overrides.md
@@ -74,6 +74,10 @@ To customize json rendering, implement the following protected controller method
 * render_validate_token_success
 * render_validate_token_error
 
+### Confirmations Controller
+* render_create_success
+* render_not_found_error
+
 ##### Example: all :controller options with default settings:
 
 ~~~ruby

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -127,7 +127,7 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
         test 'bad request on resend confirmation' do
           post :create, params: { email: nil }, xhr: true
 
-          assert_equal 400, response.status
+          assert_equal 401, response.status
         end
 
         test 'user should not be found on resend confirmation request' do

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -124,7 +124,7 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
           refute @resource.confirmed?
         end
 
-        test 'bad request on resend confirmation' do
+        test 'request resend confirmation without email' do
           post :create, params: { email: nil }, xhr: true
 
           assert_equal 401, response.status


### PR DESCRIPTION
Confirmations controller rendering methods were missing. This PR adds following rendering methods for confirmations controller:

- render_create_error_missing_email
- render_not_found_error
- render_not_found_error