### PR TITLE
CI: Use 2.5.6, 2.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ bundler_args: --without development
 rvm:
   - 2.3.8
   - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.5.6
+  - 2.6.4
 
 gemfile:
   - gemfiles/rails_4_2.gemfile
@@ -37,17 +37,17 @@ matrix:
   - rvm: 2.4.6
     gemfile: gemfiles/rails_5_1_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.5.5
+  - rvm: 2.5.6
     gemfile: gemfiles/rails_5_2_mongoid_6.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.5.5
+  - rvm: 2.5.6
     gemfile: gemfiles/rails_5_2_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.6.3
+  - rvm: 2.6.4
     gemfile: gemfiles/rails_5_2_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
   - name: Code Climate Test Coverage
-    rmv: 2.5.5
+    rmv: 2.5.6
     env:
       - CC_TEST_REPORTER_ID=44d7688de8e1b567b4af25ec5083c2cc0a355ab911192a7cbefd1ea25b2ffd3d
       - GEMFILE_AR=gemfiles/rails_5_1.gemfile
@@ -71,7 +71,7 @@ matrix:
           ./cc-test-reporter upload-coverage;
         fi
   exclude:
-    - rvm: 2.6.3
+    - rvm: 2.6.4
       gemfile: gemfiles/rails_4_2.gemfile
   fast_finish: true
 


### PR DESCRIPTION
This PR updates the CI matrix to use the latest patch releases of 2.5 and 2.6.