### PR TITLE
CI: Use ruby 2.4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ bundler_args: --without development
 
 rvm:
   - 2.3.8
-  - 2.4.6
+  - 2.4.7
   - 2.5.6
   - 2.6.4
 
@@ -34,7 +34,7 @@ matrix:
   - rvm: 2.3.8
     gemfile: gemfiles/rails_5_1_mongoid_6.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
-  - rvm: 2.4.6
+  - rvm: 2.4.7
     gemfile: gemfiles/rails_5_1_mongoid_7.gemfile
     env: DEVISE_TOKEN_AUTH_ORM=mongoid
   - rvm: 2.5.6


### PR DESCRIPTION
This PR finalized the matrix, now that rvm checksum fixes for 2.4.7 are done. 