### PR TITLE
Fix locking with unsaved changes bug

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -116,6 +116,13 @@ module DeviseTokenAuth::Concerns::SetUserByToken
   private
 
   def refresh_headers
+    # At this point restore the attributes so we can obtain the lock
+    # otherwise an exception is thrown while trying to obtain the lock
+    # with unsaved data on the resource.
+    unless const_defined?('Mongoid') do
+      @resource.restore_attributes
+    end
+    
     # Lock the user record during any auth_header updates to ensure
     # we don't have write contention from multiple threads
     @resource.with_lock do


### PR DESCRIPTION
@MaicolBen @Tiltorito

- This problem has been affecting me with `attr_encrypted` and `lockbox` gems, since they re-encrypt data on validation. 
- Breaking out the PR from here: https://github.com/lynndylanhurley/devise_token_auth/pull/1308/files
- Fixing the bug where calling `valid?` leaves unsaved changes, which throws an error when calling `@resource.with_lock`