### PR TITLE
repeat any query params after a fragment

### DIFF
--- a/lib/devise_token_auth/url.rb
+++ b/lib/devise_token_auth/url.rb
@@ -11,6 +11,9 @@ module DeviseTokenAuth::Url
     query = [uri.query, params.to_query].reject(&:blank?).join('&')
     res += "?#{query}"
     res += "##{uri.fragment}" if uri.fragment
+    # repeat any query params after the fragment to deal with Angular eating any pre fragment query params, used
+    # in the reset password redirect url
+    res += "?#{query}" if uri.fragment
 
     res
   end

--- a/test/lib/devise_token_auth/url_test.rb
+++ b/test/lib/devise_token_auth/url_test.rb
@@ -4,10 +4,10 @@ require 'test_helper'
 
 class DeviseTokenAuth::UrlTest < ActiveSupport::TestCase
   describe 'DeviseTokenAuth::Url#generate' do
-    test 'URI fragment should appear at the end of URL' do
+    test 'URI fragment should appear at the end of URL with repeat of query params' do
       params = { client_id: 123 }
       url = 'http://example.com#fragment'
-      assert_equal DeviseTokenAuth::Url.send(:generate, url, params), 'http://example.com?client_id=123#fragment'
+      assert_equal DeviseTokenAuth::Url.send(:generate, url, params), 'http://example.com?client_id=123#fragment?client_id=123'
     end
 
     describe 'with existing query params' do


### PR DESCRIPTION
Url.generate was modified in 2015 to put any query params before any fragment element of the url, based on pull https://github.com/lynndylanhurley/devise_token_auth/pull/214 which suggested that the URI RFC says fragment should be at the end and referencing a possible issue with an iOS app not being able to read query params after the fragment. In fact the RFC specifically says "The characters slash ("/") and question mark ("?") are allowed to represent data within the fragment identifier." - [https://tools.ietf.org/html/rfc3986#section-3.5]( https://tools.ietf.org/html/rfc3986#section-3.5) .

Putting the query params before the hash fragment breaks the reset password flow for Angular apps using HashLocationStrategy, i.e. the redirect to the Angular reset password component will have a hash fragment in it (see https://github.com/lynndylanhurley/devise_token_auth/issues/599 ). At this stage, 4 years later, I can imagine the maintainers of this lib will be wary of reverting to putting the params after the fragment. At the same time it feels like overkill to introduce a config element just for this (and the complexity of doing that is probably why we have no PR 3 years after the Angular issue was first raised). So what I am proposing is simply a belt and braces approach - put the query params both before and after the fragment. I have confirmed this fixes the reset password flow for Angular when using HashLocationStrategy and [https://github.com/neroniaky/angular-token](https://github.com/neroniaky/angular-token).  I  have also confirmed that this doesn't break the currently working flow for Angular apps using the default PathLocationStrategy. I've also checked the resulting rediect url with the repeated params for validity against various URL parsers and it passes. 

What do you think?