### PR TITLE
Fix dead link

### DIFF
--- a/lib/generators/devise_token_auth/USAGE
+++ b/lib/generators/devise_token_auth/USAGE
@@ -8,7 +8,7 @@ Arguments:
              # 'User'
   MOUNT_PATH # The path at which to mount the authentication routes. Default is
              # 'auth'. More detail documentation is here:
-             # https://github.com/lynndylanhurley/devise_token_auth#usage-tldr
+             # https://devise-token-auth.gitbook.io/devise-token-auth/usage
 
 Example:
   rails generate devise_token_auth:install User auth


### PR DESCRIPTION
I noticed that the usage tldr link just takes you to the main readme which doesn't have any usage info (at this time).

I was thinking it could also go here https://github.com/lynndylanhurley/devise_token_auth/tree/master/docs/usage but thought the gitbook docs looked nicer and the content is the same from what I could tell.