### PR TITLE
Remove Trackable option from generator

### DIFF
--- a/lib/generators/devise_token_auth/install_mongoid_generator.rb
+++ b/lib/generators/devise_token_auth/install_mongoid_generator.rb
@@ -29,9 +29,9 @@ module DeviseTokenAuth
   field :tokens, type: Hash, default: {}
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   index({ uid: 1, provider: 1}, { name: 'uid_provider_index', unique: true, background: true })

--- a/lib/generators/devise_token_auth/templates/user.rb.erb
+++ b/lib/generators/devise_token_auth/templates/user.rb.erb
@@ -2,8 +2,8 @@
 
 class <%= user_class %> < ActiveRecord::Base
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 end

--- a/lib/generators/devise_token_auth/templates/user_mongoid.rb.erb
+++ b/lib/generators/devise_token_auth/templates/user_mongoid.rb.erb
@@ -43,9 +43,9 @@ class <%= user_class %>
   field :tokens, type: Hash, default: {}
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   index({ email: 1 }, { name: 'email_index', unique: true, background: true })


### PR DESCRIPTION
# issue

#1356 

# WHAT

I removed `Trackable` option of resource model (ex: `User`) from generator code.

# WHY

Most of devise_token_auth users would encountered following errors, because devise_token_auth's install command does not generate columns of Trackable option by default but in the model that was created by install command is including `:trackable` option.
So I want remove it.
```
Started POST "/api/auth/sign_in" for 172.24.0.1 at 2019-11-16 07:01:57 +0000
Processing by DeviseTokenAuth::SessionsController#create as */*
  Parameters: {"email"=>"admin@example.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]", "session"=>{"email"=>"admin@example.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}}
Unpermitted parameters: :password_confirmation, :session
Unpermitted parameters: :password_confirmation, :session
  User Load (1.3ms)  SELECT `users`.* FROM `users` WHERE (BINARY email = 'admin@example.com' AND provider= 'email') ORDER BY `users`.`id` ASC LIMIT 1
Unpermitted parameters: :password_confirmation, :session
Unpermitted parameters: :password_confirmation, :session
   (0.6ms)  BEGIN
  User Update (0.8ms)  UPDATE `users` SET `users`.`tokens` = '{\"Yyo_9HeIa8IWPe4HlWl_KQ\":{\"token\":\"$2a$10$xezZ80NcEPTNGSLtM9hf1OTGwcXrtxG/KCXLncn61OhLjemZVGQW.\",\"expiry\":1576479431},\"7QLXe4cmya6gSgUpyqnhqg\":{\"token\":\"$2a$10$D62DWXQWOXGw7wcWaiAu1.JZkxHBZ3ae/zDvEzFssu6NWLtMnMWbC\",\"expiry\":1576479651},\"Pv2_ppcBK05SmSlTA7QVfA\":{\"token\":\"$2a$10$fRTY3j6wJFTqrBh5dZJZU.iqGwreW3ZdE2CWNjJv9mr6.XSFRNs/O\",\"expiry\":1576479717}}', `users`.`updated_at` = '2019-11-16 07:01:57.655591' WHERE `users`.`id` = 1
   (4.2ms)  COMMIT
Completed 500 Internal Server Error in 192ms (ActiveRecord: 6.9ms | Allocations: 5801)

NoMethodError (undefined method `current_sign_in_at' for #<User:0x000055586157b638>):

activemodel (6.0.1) lib/active_model/attribute_methods.rb:431:in `method_missing'
devise (4.7.1) lib/devise/models/trackable.rb:21:in `update_tracked_fields'
devise (4.7.1) lib/devise/models/trackable.rb:39:in `update_tracked_fields!'
devise (4.7.1) lib/devise/hooks/trackable.rb:9:in `block in <main>'
warden (1.2.8) lib/warden/hooks.rb:15:in `block in _run_callbacks'
warden (1.2.8) lib/warden/hooks.rb:10:in `each'
warden (1.2.8) lib/warden/hooks.rb:10:in `_run_callbacks'
warden (1.2.8) lib/warden/manager.rb:52:in `_run_callbacks'
warden (1.2.8) lib/warden/proxy.rb:191:in `set_user'
devise (4.7.1) lib/devise/controllers/sign_in_out.rb:53:in `sign_in'
devise_token_auth (1.1.3) app/controllers/devise_token_auth/sessions_controller.rb:32:in `create'
```

DTA was merged  a PR(https://github.com/lynndylanhurley/devise_token_auth/commit/7eeed8695280b83c9e408ac59a1c186f45769c4e) that removed columns for Trackable option.

The [devise](https://github.com/plataformatec/devise) is also not including Trackable option by default to support GDPR. [PR]([a PR that the trackable option was removed])



