### PR TITLE
fix client nil

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -194,7 +194,9 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def extend_batch_buffer(token, client)
-    tokens[client]['updated_at'] = Time.zone.now
+    if tokens[client] != nil
+      tokens[client]['updated_at'] = Time.zone.now
+    end
     update_auth_header(token, client)
   end
 

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -167,7 +167,12 @@ module DeviseTokenAuth::Concerns::User
   def build_auth_header(token, client = 'default')
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
-    expiry = tokens[client]['expiry'] || tokens[client][:expiry] || (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    
+    if  tokens[client]['expiry'].nil? || tokens[client][:expiry].nil?
+      expiry = (Time.now + DeviseTokenAuth.token_lifespan).to_i
+    else
+      expiry = tokens[client]['expiry'] || tokens[client][:expiry]
+    end
 
     {
       DeviseTokenAuth.headers_names[:"access-token"] => token,

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -196,8 +196,8 @@ module DeviseTokenAuth::Concerns::User
   def extend_batch_buffer(token, client)
     if tokens[client] != nil
       tokens[client]['updated_at'] = Time.zone.now
+      update_auth_header(token, client)      
     end
-    update_auth_header(token, client)
   end
 
   def confirmed?

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -168,7 +168,7 @@ module DeviseTokenAuth::Concerns::User
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
     
-    if  tokens[client]['expiry'].nil? || tokens[client][:expiry].nil?
+    if tokens[client].nil?
       expiry = (Time.now + DeviseTokenAuth.token_lifespan).to_i
     else
       expiry = tokens[client]['expiry'] || tokens[client][:expiry]

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -167,7 +167,7 @@ module DeviseTokenAuth::Concerns::User
   def build_auth_header(token, client = 'default')
     # client may use expiry to prevent validation request if expired
     # must be cast as string or headers will break
-    expiry = tokens[client]['expiry'] || tokens[client][:expiry]
+    expiry = tokens[client]['expiry'] || tokens[client][:expiry] || (Time.now + DeviseTokenAuth.token_lifespan).to_i
 
     {
       DeviseTokenAuth.headers_names[:"access-token"] => token,
@@ -196,8 +196,9 @@ module DeviseTokenAuth::Concerns::User
   def extend_batch_buffer(token, client)
     if tokens[client] != nil
       tokens[client]['updated_at'] = Time.zone.now
-      update_auth_header(token, client)      
     end
+
+    update_auth_header(token, client) 
   end
 
   def confirmed?


### PR DESCRIPTION
In our case it happened that the client was an empty hash, because the user was authenticated from a different place. Although, in order to get the access to swagger, with was mounted into the api, we needed to go through the main Api controller.

That resolved in ```undefined method `[]=' for nil:NilClass```

The solution is quite simple and it's just a nil check