### PR TITLE
Fix missing polish and portugese missing translation errors

### DIFF
--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -26,9 +26,10 @@ pl:
       missing_passwords: "Musisz wypełnić wszystkie pola z etykietą 'Hasło' oraz 'Potwierdzenie hasła'."
       successfully_updated: "Twoje hasło zostało zaktualizowane."
   errors:
-    validate_sign_up_params: "Proszę dostarczyć odpowiednie dane logowania w ciele zapytania."
-    validate_account_update_params: "Proszę dostarczyć odpowiednie dane aktualizacji konta w ciele zapytania."
-    not_email: "nie jest prawidłowym adresem e-mail"
+    messages:
+      validate_sign_up_params: "Proszę dostarczyć odpowiednie dane logowania w ciele zapytania."
+      validate_account_update_params: "Proszę dostarczyć odpowiednie dane aktualizacji konta w ciele zapytania."
+      not_email: "nie jest prawidłowym adresem e-mail"
   devise:
     mailer:
       confirmation_instructions:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -26,9 +26,10 @@ pt:
       missing_passwords: "Preencha a senha e a confirmação de senha."
       successfully_updated: "Senha atualizada com sucesso."
   errors:
-    validate_sign_up_params: "Os dados submetidos na requisição de registo são inválidos."
-    validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
-    not_email: "não é um e-mail"
+    messages:
+      validate_sign_up_params: "Os dados submetidos na requisição de registo são inválidos."
+      validate_account_update_params: "Os dados submetidos para atualização de conta são inválidos."
+      not_email: "não é um e-mail"
   devise:
     mailer:
       confirmation_instructions:


### PR DESCRIPTION
There was a missing `message` parent attribute for following traslations (polish and portugese):
- `errors.messages.validate_sign_up_params`
- `errors.messages.validate_account_update_params`
- `errors.messages.not_email`

The rest of locales are ok.