### PR TITLE
Serialize updated at without to s

### DIFF
--- a/app/models/devise_token_auth/concerns/tokens_serialization.rb
+++ b/app/models/devise_token_auth/concerns/tokens_serialization.rb
@@ -1,8 +1,14 @@
 module DeviseTokenAuth::Concerns::TokensSerialization
   # Serialization hash to json
   def self.dump(object)
-    object.each_value(&:compact!) unless object.nil?
-    JSON.generate(object)
+    object.each_value do |value|
+      if (updated_at_key = ['updated_at', :updated_at].find(&value.method(:[])))
+        if value[updated_at_key].respond_to?(:iso8601)
+          value[updated_at_key] = value[updated_at_key].iso8601
+        end
+      end
+      value.compact!
+    end unless object.nil?
   end
 
   # Deserialization json to hash

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_4_2_mongoid_5.gemfile
+++ b/gemfiles/rails_4_2_mongoid_5.gemfile
@@ -34,7 +34,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1_mongoid_6.gemfile
+++ b/gemfiles/rails_5_1_mongoid_6.gemfile
@@ -34,7 +34,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1_mongoid_7.gemfile
+++ b/gemfiles/rails_5_1_mongoid_7.gemfile
@@ -34,7 +34,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2_mongoid_6.gemfile
+++ b/gemfiles/rails_5_2_mongoid_6.gemfile
@@ -34,7 +34,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2_mongoid_7.gemfile
+++ b/gemfiles/rails_5_2_mongoid_7.gemfile
@@ -34,7 +34,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_6_0_mongoid_7.gemfile
+++ b/gemfiles/rails_6_0_mongoid_7.gemfile
@@ -34,7 +34,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 end
 
 group :development do

--- a/test/models/concerns/tokens_serialization_test.rb
+++ b/test/models/concerns/tokens_serialization_test.rb
@@ -65,6 +65,35 @@ if DEVISE_TOKEN_AUTH_ORM == :active_record
 
         assert_equal(ts.dump(tokens), ts.dump(new_tokens))
       end
+
+      describe 'updated_at' do
+        before do
+          @default_format = ::Time::DATE_FORMATS[:default]
+          ::Time::DATE_FORMATS[:default] = 'imprecise format'
+        end
+
+        after do
+          ::Time::DATE_FORMATS[:default] = @default_format
+        end
+
+        let(:updated_ats) { tokens.values.flat_map { |token| [:updated_at, 'updated_at'].map { |key| token[key] } }.compact.map(&:to_s) }
+
+        it 'is defined' do
+          refute_empty updated_ats
+        end
+
+        it 'uses iso8601' do
+          as_json = updated_ats.map do |time_string|
+            Time.zone.parse(time_string).iso8601
+          end
+
+          assert_equal(updated_ats, as_json)
+        end
+
+        it 'does not rely on Time#to_s' do
+          refute_includes(updated_ats, 'imprecise format')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The project I'm on has an overridden ::Time::DATE_FORMATS[:default] that does not include the seconds in the serialized time string. This broke batch detection in a way that was very difficult to track down. This PR uses [iso8601](https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-iso8601) To serialize reliably.