### PR TITLE
Validate that token is valid for patch request last token

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -137,17 +137,17 @@ module DeviseTokenAuth::Concerns::User
   def token_can_be_reused?(token, client)
     # ghetto HashWithIndifferentAccess
     updated_at = tokens[client]['updated_at'] || tokens[client][:updated_at]
-    last_token = tokens[client]['last_token'] || tokens[client][:last_token]
+    last_token_hash = tokens[client]['last_token'] || tokens[client][:last_token]
 
     return true if (
       # ensure that the last token and its creation time exist
-      updated_at && last_token &&
+      updated_at && last_token_hash &&
 
       # ensure that previous token falls within the batch buffer throttle time of the last request
       updated_at.to_time > Time.zone.now - DeviseTokenAuth.batch_request_buffer_throttle &&
 
       # ensure that the token is valid
-      DeviseTokenAuth::TokenFactory.valid_token_hash?(last_token)
+      DeviseTokenAuth::TokenFactory.token_hash_is_token?(last_token_hash, token)
     )
   end
 


### PR DESCRIPTION
When in patch requests if any token is passed with right client id it passes and consider the user as logged in because we only that last token which is saved in the db is a valid hash and we don't check it against the token sent by the user.