### PR TITLE
Fix token-type header key in testing example docs

### DIFF
--- a/docs/usage/testing.md
+++ b/docs/usage/testing.md
@@ -113,7 +113,7 @@ describe 'Whether access is ocurring properly', type: :request do
       'client' => client,
       'uid' => uid,
       'expiry' => expiry,
-      'token_type' => token_type
+      'token-type' => token_type
     }
     auth_params
   end


### PR DESCRIPTION
This matches the header key in the response a few lines above the change.

I also wonder if the `expiry` and `token-type` keys should be included in `auth_params`. It seems like they're not really required for the authentication to work, even though they're part of auth params in the general sense. The example made me believe that they're required in the request for the authentication to work.