### PR TITLE
Fix: Save user authentication token after email confirmation

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -13,6 +13,7 @@ module DeviseTokenAuth
 
         if signed_in?(resource_name)
           token = signed_in_resource.create_token
+          signed_in_resource.save!
 
           redirect_headers = build_redirect_headers(token.token,
                                                     token.client,

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -53,6 +53,10 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
             assert @resource.confirmed?
           end
 
+          test 'should save the authentication token' do
+            assert @resource.reload.tokens.present?
+          end
+
           test 'should redirect to success url' do
             assert_redirected_to(/^#{@redirect_url}/)
           end


### PR DESCRIPTION
## Fix
### Problem
When trying to sign in a user after the confirmation we are supposed to do this in the show method of the `confirmations_controller` like:
```
super do |resource|
  sign_in(resource) if resource.errors.empty?
end
```
The problem with this is that later on this method creates a token for the user, but never saves it.

### Solution
```
if signed_in?(resource_name)
  token = signed_in_resource.create_token
  signed_in_resource.save!    <-- Added this line

  redirect_headers = build_redirect_headers(token.token,
                                                    token.client,
                                                    redirect_header_options)

  redirect_to_link = signed_in_resource.build_auth_url(redirect_url, redirect_headers)
else
   redirect_to_link = DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
end
```