### PR TITLE
CI build fix: Pin to pry < 0.13 for 2.3 support, workaround CodeClimate reporter issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,11 @@ matrix:
         - bundle install --jobs=3 --retry=3 --gemfile $GEMFILE_AR
         - BUNDLE_GEMFILE=$GEMFILE_AR bundle exec rake --trace db:migrate
         - BUNDLE_GEMFILE=$GEMFILE_AR bundle exec rake
-        - ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.active_record.json coverage/.resultset.json
+        - ./cc-test-reporter format-coverage coverage/.resultset.json -t simplecov -o coverage/codeclimate.active_record.json
         # with Mongoid
         - bundle install --jobs=3 --retry=3 --gemfile $GEMFILE_MONGOID
         - BUNDLE_GEMFILE=$GEMFILE_MONGOID DEVISE_TOKEN_AUTH_ORM=mongoid bundle exec rake
-        - ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.mongoid.json coverage/.resultset.json
+        - ./cc-test-reporter format-coverage coverage/.resultset.json -t simplecov -o coverage/codeclimate.mongoid.json
         # merge test results
         - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then
           ./cc-test-reporter sum-coverage coverage/codeclimate.active_record.json coverage/codeclimate.mongoid.json;

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false

--- a/gemfiles/rails_4_2_mongoid_5.gemfile
+++ b/gemfiles/rails_4_2_mongoid_5.gemfile
@@ -8,6 +8,7 @@ gem "mongoid-locker", "~> 1.0"
 
 group :development, :test do
   gem "attr_encrypted"
+  gem "byebug", "< 11.1"
   gem "figaro", git: "https://github.com/laserlemon/figaro"
   gem "omniauth-facebook", git: "https://github.com/mkdynamic/omniauth-facebook"
   gem "omniauth-github", git: "https://github.com/intridea/omniauth-github"
@@ -26,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -35,7 +35,11 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+
+  # Workaround for cc-test-reporter with SimpleCov 0.18.
+  # Stop upgrading SimpleCov until the following issue will be resolved.
+  # https://github.com/codeclimate/test-reporter/issues/418
+  gem 'simplecov', '~> 0.10', '< 0.18', require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1_mongoid_6.gemfile
+++ b/gemfiles/rails_5_1_mongoid_6.gemfile
@@ -8,6 +8,7 @@ gem "mongoid-locker", "~> 1.0"
 
 group :development, :test do
   gem "attr_encrypted"
+  gem "byebug", "< 11.1"
   gem "figaro", git: "https://github.com/laserlemon/figaro"
   gem "omniauth-facebook", git: "https://github.com/mkdynamic/omniauth-facebook"
   gem "omniauth-github", git: "https://github.com/intridea/omniauth-github"
@@ -26,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false

--- a/gemfiles/rails_5_1_mongoid_7.gemfile
+++ b/gemfiles/rails_5_1_mongoid_7.gemfile
@@ -34,7 +34,11 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+
+  # Workaround for cc-test-reporter with SimpleCov 0.18.
+  # Stop upgrading SimpleCov until the following issue will be resolved.
+  # https://github.com/codeclimate/test-reporter/issues/418
+  gem 'simplecov', '~> 0.10', '< 0.18', require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem "minitest-rails"
   gem "minitest-reporters"
   gem "mocha", ">= 1.5"
-  gem "pry"
+  gem "pry", "< 0.13"
   gem "pry-byebug"
   gem "pry-remote"
   gem "rubocop", require: false


### PR DESCRIPTION
This PR tries to fix the pry-byebug compatibility by pinning to older releases of `pry`, which are supported.

This gem raises the error: it can not yet interact with pry 0.13 at the version we use (we need to use that version due to 2.3).

[pry-byebug CHANGELOG](https://github.com/deivid-rodriguez/pry-byebug/blob/master/CHANGELOG.md)

- pin pry
- pin byebug in one case
- pin to 0.17 of simplecov, to have codeclimate support (see https://github.com/codeclimate/test-reporter/issues/413 for "codeclimate not yet support 0.18" information)

🍏 **Build is now passing**