### PR TITLE
[Refactor] fixed "not_email" setting in ja.yml

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -29,7 +29,7 @@ ja:
     messages:
       validate_sign_up_params: "リクエストボディに適切なアカウント新規登録データを送信してください。"
       validate_account_update_params: "リクエストボディに適切なアカウント更新のデータを送信してください。"
-      not_email: "はメールアドレスではありません"
+      not_email: "は有効ではありません"
   devise:
     mailer:
       confirmation_instructions:


### PR DESCRIPTION
Hi, I'm using this gem and I found the not suitable translation on "not_email" setting in ja.yml, when creating authentication system.
When I put the test email address which creates error message in form on login page on purpose, I get error like this:

`"メールアドレスはメールアドレスではありません"`
this means `"Email is not Email"` in English. its very strange.

I think we expect it to be applied for inputted `Email`, not `"Email"(Label name)`.
example:
`"example@tはメールアドレスではありません"`
this means `"example@t is not Email"` in English, I think this is correct.

So I recommend you to fix the word as `"は有効ではありません"`
this means `is not valid`, but its very readable for Japanese in this situation
And its suitable for label name and Email both.

`"メールアドレスは有効ではありません"`
=> `"Email is not valid"`

`"example@tは有効ではありません"`
=> `"example@t is not valid."`

I think the meanings are correct both.
