### PR TITLE
Update assign_provider_attrs to strip 'name' field

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -112,7 +112,8 @@ module DeviseTokenAuth
 
     # break out provider attribute assignment for easy method extension
     def assign_provider_attrs(user, auth_hash)
-      attrs = auth_hash['info'].slice(*user.attribute_names)
+      attrs = auth_hash['info'].to_hash
+      attrs = attrs.slice(*user.attribute_names)
       user.assign_attributes(attrs)
     end
 


### PR DESCRIPTION
The OmniAuth InfoHash class overrides its to_hash method to explicitly define the name field.

Rails converts the info hash to a hash when user.assign_attributes is called.

If the applications user table does not have a name field, this will cause a ForbiddenAttributesError.

This pr updates the assign_provider_attrs function to explicitly convert the InfoHash to a hash before slicing out the unused attributes.