### PR TITLE
Allow customized controllers to be added to devise_for

### DIFF
--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -17,10 +17,12 @@ module ActionDispatch::Routing
       unlocks_ctrl           = opts[:controllers][:unlocks] || 'devise_token_auth/unlocks'
 
       # define devise controller mappings
-      controllers = { sessions: sessions_ctrl,
-                      registrations: registrations_ctrl,
-                      passwords: passwords_ctrl,
-                      confirmations: confirmations_ctrl }
+      controllers = opts[:controllers].merge(
+        sessions: sessions_ctrl,
+        registrations: registrations_ctrl,
+        passwords: passwords_ctrl,
+        confirmations: confirmations_ctrl
+      )
 
       controllers[:unlocks] = unlocks_ctrl if unlocks_ctrl
 

--- a/test/dummy/app/active_record/scoped_user.rb
+++ b/test/dummy/app/active_record/scoped_user.rb
@@ -6,4 +6,6 @@ class ScopedUser < ActiveRecord::Base
          :recoverable, :rememberable,
          :validatable, :confirmable, :omniauthable
   include DeviseTokenAuth::Concerns::User
+
+  devise :omniauthable
 end

--- a/test/dummy/app/active_record/user.rb
+++ b/test/dummy/app/active_record/user.rb
@@ -3,4 +3,6 @@
 class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
   include FavoriteColor
+
+  devise :omniauthable
 end

--- a/test/dummy/app/mongoid/scoped_user.rb
+++ b/test/dummy/app/mongoid/scoped_user.rb
@@ -47,4 +47,6 @@ class ScopedUser
          :recoverable, :rememberable, :trackable,
          :validatable, :confirmable, :omniauthable
   include DeviseTokenAuth::Concerns::User
+
+  devise :omniauthable
 end

--- a/test/dummy/app/mongoid/user.rb
+++ b/test/dummy/app/mongoid/user.rb
@@ -46,4 +46,6 @@ class User
 
   include DeviseTokenAuth::Concerns::User
   include FavoriteColor
+
+  devise :omniauthable
 end

--- a/test/lib/devise_token_auth/rails/routes_test.rb
+++ b/test/lib/devise_token_auth/rails/routes_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeviseTokenAuth::RoutesTest < ActionController::TestCase
+  describe '#mount_devise_token_auth_for' do
+    before do
+      Rails.application.routes.draw do
+        mount_devise_token_auth_for 'User', at: 'my_custom_users', controllers: {
+          invitations: 'custom/invitations',
+          foo: 'custom/foo'
+        }
+      end
+    end
+
+    after do
+      Rails.application.reload_routes!
+    end
+
+    test 'map new user session' do
+      assert_recognizes({controller: 'devise_token_auth/sessions', action: 'new'}, {path: 'my_custom_users/sign_in', method: :get})
+    end
+
+    test 'map create user session' do
+      assert_recognizes({controller: 'devise_token_auth/sessions', action: 'create'}, {path: 'my_custom_users/sign_in', method: :post})
+    end
+
+    test 'map destroy user session' do
+      assert_recognizes({controller: 'devise_token_auth/sessions', action: 'destroy'}, {path: 'my_custom_users/sign_out', method: :delete})
+    end
+
+    test 'map new user confirmation' do
+      assert_recognizes({controller: 'devise_token_auth/confirmations', action: 'new'}, 'my_custom_users/confirmation/new')
+    end
+
+    test 'map create user confirmation' do
+      assert_recognizes({controller: 'devise_token_auth/confirmations', action: 'create'}, {path: 'my_custom_users/confirmation', method: :post})
+    end
+
+    test 'map show user confirmation' do
+      assert_recognizes({controller: 'devise_token_auth/confirmations', action: 'show'}, {path: 'my_custom_users/confirmation', method: :get})
+    end
+
+    test 'map new user password' do
+      assert_recognizes({controller: 'devise_token_auth/passwords', action: 'new'}, 'my_custom_users/password/new')
+    end
+
+    test 'map create user password' do
+      assert_recognizes({controller: 'devise_token_auth/passwords', action: 'create'}, {path: 'my_custom_users/password', method: :post})
+    end
+
+    test 'map edit user password' do
+      assert_recognizes({controller: 'devise_token_auth/passwords', action: 'edit'}, 'my_custom_users/password/edit')
+    end
+
+    test 'map update user password' do
+      assert_recognizes({controller: 'devise_token_auth/passwords', action: 'update'}, {path: 'my_custom_users/password', method: :put})
+    end
+
+    test 'map new user registration' do
+      assert_recognizes({controller: 'devise_token_auth/registrations', action: 'new'}, 'my_custom_users/sign_up')
+    end
+
+    test 'map create user registration' do
+      assert_recognizes({controller: 'devise_token_auth/registrations', action: 'create'}, {path: 'my_custom_users', method: :post})
+    end
+
+    test 'map edit user registration' do
+      assert_recognizes({controller: 'devise_token_auth/registrations', action: 'edit'}, {path: 'my_custom_users/edit', method: :get})
+    end
+
+    test 'map update user registration' do
+      assert_recognizes({controller: 'devise_token_auth/registrations', action: 'update'}, {path: 'my_custom_users', method: :put})
+    end
+
+    test 'map destroy user registration' do
+      assert_recognizes({controller: 'devise_token_auth/registrations', action: 'destroy'}, {path: 'my_custom_users', method: :delete})
+    end
+
+    test 'map cancel user registration' do
+      assert_recognizes({controller: 'devise_token_auth/registrations', action: 'cancel'}, {path: 'my_custom_users/cancel', method: :get})
+    end
+  end
+end


### PR DESCRIPTION
# Why?

* Currently there is no way to add customized controller when using `mount_devise_token_auth_for`. See more at https://github.com/lynndylanhurley/devise_token_auth/blob/master/lib/devise_token_auth/rails/routes.rb#L10-L23. For eg: adding customized controller for https://github.com/scambra/devise_invitable#configuring-controllers-.

# How?

* Allow controller option when using `mount_devise_token_auth_for`. Eg:
```ruby
  mount_devise_token_auth_for 'User', at: 'users', skip: [], controllers: {
      sessions:  'api/users/sessions',
      passwords:  'api/users/passwords',
      token_validations:  'api/users/token_validations',
      invitations: 'api/users/invitations'
    }
```