### PR TITLE
missing space in migration generator

### DIFF
--- a/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth_create_users.rb.erb
@@ -44,6 +44,6 @@ class DeviseTokenAuthCreate<%= user_class.pluralize.gsub("::","") %> < ActiveRec
     add_index :<%= table_name %>, [:uid, :provider],     unique: true
     add_index :<%= table_name %>, :reset_password_token, unique: true
     add_index :<%= table_name %>, :confirmation_token,   unique: true
-    # add_index :<%= table_name %>, :unlock_token,       unique: true
+    # add_index :<%= table_name %>, :unlock_token,         unique: true
   end
 end


### PR DESCRIPTION
Very minor and usless but by doing so everything is nicely aligned if you uncomment this