### PR TITLE
Remove unnecessary require_relative the file should be autoloaded

### DIFF
--- a/app/models/devise_token_auth/concerns/active_record_support.rb
+++ b/app/models/devise_token_auth/concerns/active_record_support.rb
@@ -1,5 +1,3 @@
-require_relative 'tokens_serialization'
-
 module DeviseTokenAuth::Concerns::ActiveRecordSupport
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
Remove unnecessary require_relative the file should be autoloaded - for me at least this breaks zeitwerk (DeviseTokenAuth::Concerns::TokensSerialization is already autoloaded)