### PR TITLE
make DTA respect controller overrides it doesn't know about

### DIFF
--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -8,19 +8,21 @@ module ActionDispatch::Routing
       opts[:skip]        ||= []
 
       # check for ctrl overrides, fall back to defaults
-      sessions_ctrl          = opts[:controllers][:sessions] || 'devise_token_auth/sessions'
-      registrations_ctrl     = opts[:controllers][:registrations] || 'devise_token_auth/registrations'
-      passwords_ctrl         = opts[:controllers][:passwords] || 'devise_token_auth/passwords'
-      confirmations_ctrl     = opts[:controllers][:confirmations] || 'devise_token_auth/confirmations'
-      token_validations_ctrl = opts[:controllers][:token_validations] || 'devise_token_auth/token_validations'
-      omniauth_ctrl          = opts[:controllers][:omniauth_callbacks] || 'devise_token_auth/omniauth_callbacks'
-      unlocks_ctrl           = opts[:controllers][:unlocks] || 'devise_token_auth/unlocks'
+      sessions_ctrl          = opts[:controllers].delete(:sessions) || 'devise_token_auth/sessions'
+      registrations_ctrl     = opts[:controllers].delete(:registrations) || 'devise_token_auth/registrations'
+      passwords_ctrl         = opts[:controllers].delete(:passwords) || 'devise_token_auth/passwords'
+      confirmations_ctrl     = opts[:controllers].delete(:confirmations) || 'devise_token_auth/confirmations'
+      token_validations_ctrl = opts[:controllers].delete(:token_validations) || 'devise_token_auth/token_validations'
+      omniauth_ctrl          = opts[:controllers].delete(:omniauth_callbacks) || 'devise_token_auth/omniauth_callbacks'
+      unlocks_ctrl           = opts[:controllers].delete(:unlocks) || 'devise_token_auth/unlocks'
 
       # define devise controller mappings
-      controllers = { sessions: sessions_ctrl,
+      controllers = opts[:controllers].merge(
+                      sessions: sessions_ctrl,
                       registrations: registrations_ctrl,
                       passwords: passwords_ctrl,
-                      confirmations: confirmations_ctrl }
+                      confirmations: confirmations_ctrl
+                    )
 
       controllers[:unlocks] = unlocks_ctrl if unlocks_ctrl
 

--- a/test/lib/devise_token_auth/rails/custom_routes_test.rb
+++ b/test/lib/devise_token_auth/rails/custom_routes_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeviseTokenAuth::CustomRoutesTest < ActiveSupport::TestCase
+  after do
+    Rails.application.reload_routes!
+  end
+  test 'custom controllers' do
+    class ActionDispatch::Routing::Mapper
+        include Mocha::ParameterMatchers
+    end
+    Rails.application.routes.draw do
+      self.expects(:devise_for).with(
+        :users,
+        has_entries(
+          controllers: has_entries(
+            invitations: "custom/invitations", foo: "custom/foo"
+          )
+        )
+      )
+
+      mount_devise_token_auth_for 'User', at: 'my_custom_users', controllers: {
+        invitations: 'custom/invitations',
+        foo: 'custom/foo'
+      }
+    end
+  end
+end

--- a/test/lib/devise_token_auth/rails/routes_test.rb
+++ b/test/lib/devise_token_auth/rails/routes_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Needed for MiniTest to start a controller test so we can use assert_recognizes
+class DeviseTokenAuth::RoutesTestController < DeviseTokenAuth::ApplicationController
+end
+
+class DeviseTokenAuth::RoutesTest < ActionController::TestCase
+  self.controller_class = DeviseTokenAuth::RoutesTestController
+  before do
+    Rails.application.routes.draw do
+      mount_devise_token_auth_for 'User', at: 'my_custom_users', controllers: {
+        invitations: 'custom/invitations',
+        foo: 'custom/foo'
+      }
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  test 'map new user session' do
+    assert_recognizes({controller: 'devise_token_auth/sessions', action: 'new'}, {path: 'my_custom_users/sign_in', method: :get})
+  end
+
+  test 'map create user session' do
+    assert_recognizes({controller: 'devise_token_auth/sessions', action: 'create'}, {path: 'my_custom_users/sign_in', method: :post})
+  end
+
+  test 'map destroy user session' do
+    assert_recognizes({controller: 'devise_token_auth/sessions', action: 'destroy'}, {path: 'my_custom_users/sign_out', method: :delete})
+  end
+
+  test 'map new user confirmation' do
+    assert_recognizes({controller: 'devise_token_auth/confirmations', action: 'new'}, 'my_custom_users/confirmation/new')
+  end
+
+  test 'map create user confirmation' do
+    assert_recognizes({controller: 'devise_token_auth/confirmations', action: 'create'}, {path: 'my_custom_users/confirmation', method: :post})
+  end
+
+  test 'map show user confirmation' do
+    assert_recognizes({controller: 'devise_token_auth/confirmations', action: 'show'}, {path: 'my_custom_users/confirmation', method: :get})
+  end
+
+  test 'map new user password' do
+    assert_recognizes({controller: 'devise_token_auth/passwords', action: 'new'}, 'my_custom_users/password/new')
+  end
+
+  test 'map create user password' do
+    assert_recognizes({controller: 'devise_token_auth/passwords', action: 'create'}, {path: 'my_custom_users/password', method: :post})
+  end
+
+  test 'map edit user password' do
+    assert_recognizes({controller: 'devise_token_auth/passwords', action: 'edit'}, 'my_custom_users/password/edit')
+  end
+
+  test 'map update user password' do
+    assert_recognizes({controller: 'devise_token_auth/passwords', action: 'update'}, {path: 'my_custom_users/password', method: :put})
+  end
+
+  test 'map new user registration' do
+    assert_recognizes({controller: 'devise_token_auth/registrations', action: 'new'}, 'my_custom_users/sign_up')
+  end
+
+  test 'map create user registration' do
+    assert_recognizes({controller: 'devise_token_auth/registrations', action: 'create'}, {path: 'my_custom_users', method: :post})
+  end
+
+  test 'map edit user registration' do
+    assert_recognizes({controller: 'devise_token_auth/registrations', action: 'edit'}, {path: 'my_custom_users/edit', method: :get})
+  end
+
+  test 'map update user registration' do
+    assert_recognizes({controller: 'devise_token_auth/registrations', action: 'update'}, {path: 'my_custom_users', method: :put})
+  end
+
+  test 'map destroy user registration' do
+    assert_recognizes({controller: 'devise_token_auth/registrations', action: 'destroy'}, {path: 'my_custom_users', method: :delete})
+  end
+
+  test 'map cancel user registration' do
+    assert_recognizes({controller: 'devise_token_auth/registrations', action: 'cancel'}, {path: 'my_custom_users/cancel', method: :get})
+  end
+end


### PR DESCRIPTION
This builds off of https://github.com/lynndylanhurley/devise_token_auth/pull/1420 and also tries to add tests for the routing logic.

To reiterate from that PR:

## Why?

Currently there is no way to add customized controller when using mount_devise_token_auth_for. See more at https://github.com/lynndylanhurley/devise_token_auth/blob/master/lib/devise_token_auth/rails/routes.rb#L10-L23. For eg: adding customized controller for https://github.com/scambra/devise_invitable#configuring-controllers-.

## How?
Allow controller option when using mount_devise_token_auth_for. Eg:
```  mount_devise_token_auth_for 'User', at: 'users', skip: [], controllers: {
      sessions:  'api/users/sessions',
      passwords:  'api/users/passwords',
      token_validations:  'api/users/token_validations',
      invitations: 'api/users/invitations'
    }