### PR TITLE
Multi token lifespan

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -90,6 +90,7 @@ module DeviseTokenAuth::Concerns::User
     end
 
     def create_token(client: nil, lifespan: nil, cost: nil, **token_extras)
+      lifespan ||= token_lifespan
       token = DeviseTokenAuth::TokenFactory.create(client: client, lifespan: lifespan, cost: cost)
 
       tokens[token.client] = {
@@ -253,5 +254,9 @@ module DeviseTokenAuth::Concerns::User
       #   off the Hash until it no longer exceeds the maximum number of clients
       tokens.shift while max_client_tokens_exceeded?
     end
+  end
+
+  def token_lifespan
+    DeviseTokenAuth.token_lifespan
   end
 end

--- a/docs/usage/multiple_models.md
+++ b/docs/usage/multiple_models.md
@@ -47,6 +47,24 @@ This gem supports the use of multiple user models. One possible use case is to a
   * `current_admin`
   * `admin_signed_in?`
 
+1. (Optional) Configure custom token lifespan
+  **Example**:
+
+  ~~~ruby
+  Class Admin
+    # Devise configuration
+    devise :invitable, :database_authenticatable, :recoverable, :rememberable, :validatable
+    include DeviseTokenAuth::Concerns::User
+
+    protected
+
+    def token_lifespan
+      1.day
+    end
+  end
+  ~~~
+
+
 
 ### Group access
 


### PR DESCRIPTION
When using multiple User classes, the token lifespan is the same for every class, this PR allows to override this default token and use a custom one in a specific class