### PR TITLE
Fix sending a confirmation email via Devise

### DIFF
--- a/app/controllers/devise_token_auth/registrations_controller.rb
+++ b/app/controllers/devise_token_auth/registrations_controller.rb
@@ -30,11 +30,6 @@ module DeviseTokenAuth
       # if whitelist is set, validate redirect_url against whitelist
       return render_create_error_redirect_url_not_allowed if blacklisted_redirect_url?(@redirect_url)
 
-      # override email confirmation, must be sent manually from ctrl
-      callback_name = defined?(ActiveRecord) && resource_class < ActiveRecord::Base ? :commit : :create
-      resource_class.set_callback(callback_name, :after, :send_on_create_confirmation_instructions)
-      resource_class.skip_callback(callback_name, :after, :send_on_create_confirmation_instructions)
-
       if @resource.respond_to? :skip_confirmation_notification!
         # Fix duplicate e-mails by disabling Devise confirmation e-mail
         @resource.skip_confirmation_notification!

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -112,10 +112,6 @@ module DeviseTokenAuth::Concerns::User
     false
   end
 
-  # this must be done from the controller so that additional params
-  # can be passed on from the client
-  def send_confirmation_notification?; false; end
-
   def token_is_current?(token, client)
     # ghetto HashWithIndifferentAccess
     expiry     = tokens[client]['expiry'] || tokens[client][:expiry]


### PR DESCRIPTION
We can't get a confirmation email in a registration via Devise when we are using Devise and devise_token_auth.
This gem has already skipped a confirmation notification in the controller, so other codes just broke original Devise implements.

https://github.com/lynndylanhurley/devise_token_auth/blob/5ef7197d5e2ca50f7fc92a7b04884341759b6e87/app/controllers/devise_token_auth/registrations_controller.rb#L38-L41

I created a [sample repository](https://github.com/rono23/DTASample) to test a confirmation email in registration.
This sample repository failed to test after installing devise_token_auth.

Sorry, I'm not good at English and I started to use this gem recently.
