### PR TITLE
not work alongside standard Devise for class with namespace, use mapping directly as scope

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -46,7 +46,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     # check for an existing user, authenticated via warden/devise, if enabled
     if DeviseTokenAuth.enable_standard_devise_support
-      devise_warden_user = warden.user(rc.to_s.underscore.to_sym)
+      devise_warden_user = warden.user(mapping)
       if devise_warden_user && devise_warden_user.tokens[@token.client].nil?
         @used_auth_by_token = false
         @resource = devise_warden_user


### PR DESCRIPTION
When using alongside standard Devise, existing user can't be found in case of class with namespace.

https://github.com/heartcombo/devise/blob/master/lib/devise/controllers/helpers.rb#L48
`rc` would be something like `myapp/user`, use `mapping` directly as `scope` to keep consistency of behavior with devise.