### PR TITLE
Enhancement: render auth headers only in the response body on sign in

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -6,6 +6,8 @@ module DeviseTokenAuth
     before_action :set_user_by_token, only: [:destroy]
     after_action :reset_session, only: [:destroy]
 
+    skip_after_action :update_auth_header, only: [:create]
+
     def new
       render_new_error
     end
@@ -95,8 +97,11 @@ module DeviseTokenAuth
     end
 
     def render_create_success
+      # Auth headers should be included in the response body the
+      # first time according to https://tools.ietf.org/html/rfc6750#page-10
       render json: {
-        data: resource_data(resource_json: @resource.token_validation_response)
+        data: resource_data(resource_json: @resource.token_validation_response),
+        auth_data: @resource.build_auth_header(@token.token, @token.client)
       }
     end
 

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -35,6 +35,26 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
           assert_equal @existing_user.email, @data['data']['email']
         end
 
+        test 'request should not return created_at data' do
+          assert_nil @data['data']['created_at']
+        end
+
+        test 'request should not return updated_at data' do
+          assert_nil @data['data']['updated_at']
+        end
+
+        test 'request should not return tokens data' do
+          assert_nil @data['data']['tokens']
+        end
+
+        test 'request should return auth data in the body' do
+          assert_equal @existing_user.uid, @data['auth_data']['uid']
+        end
+
+        test 'request should not return auth data in the headers' do
+          assert_nil response.headers['uid']
+        end
+
         describe "with multiple clients and headers don't change in each request" do
           before do
             # Set the max_number_of_devices to a lower number


### PR DESCRIPTION
### Description:

In this PR there is an enhancement for the session's creation. On sign-in, the client [should receive the "auth headers" in the body](https://tools.ietf.org/html/rfc6750#page-10).

This is a breaking change for all the clients using this gem, so I'd like some input on how to improve this and add some warnings to the users 😄 