### PR TITLE
Add email validation errors via add

### DIFF
--- a/app/validators/devise_token_auth_email_validator.rb
+++ b/app/validators/devise_token_auth_email_validator.rb
@@ -3,7 +3,7 @@
 class DeviseTokenAuthEmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-      record.errors[attribute] << email_invalid_message
+      record.errors.add(attribute, email_invalid_message)
     end
   end
 


### PR DESCRIPTION
Fixes deprecation warning introduced in https://github.com/rails/rails/pull/32313

```ruby
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from validate_each at .../ruby/2.7.2/lib/ruby/gems/2.7.0/gems/devise_token_auth-1.1.3/app/validators/devise_token_auth_email_validator.rb:6)
```