### PR TITLE
Fix Rails 6.1 Deprecation warning by updating connection_config to connection_db_config

### DIFF
--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -20,7 +20,7 @@ module DeviseTokenAuth::Concerns::ResourceFinder
   end
 
   def find_resource(field, value)
-    @resource = if resource_class.try(:connection_config).try(:[], :adapter).try(:include?, 'mysql')
+    @resource = if resource_class.try(:connection_db_config).try(:[], :adapter).try(:include?, 'mysql')
                   # fix for mysql default case insensitivity
                   resource_class.where("BINARY #{field} = ? AND provider= ?", value, provider).first
                 else

--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -20,12 +20,7 @@ module DeviseTokenAuth::Concerns::ResourceFinder
   end
 
   def find_resource(field, value)
-    @resource = if resource_class.try(:connection_db_config).try(:[], :adapter).try(:include?, 'mysql')
-                  # fix for mysql default case insensitivity
-                  resource_class.where("BINARY #{field} = ? AND provider= ?", value, provider).first
-                else
-                  resource_class.dta_find_by(field => value, 'provider' => provider)
-                end
+    @resource = resource_class.dta_find_by(field => value, 'provider' => provider)
   end
 
   def resource_class(m = nil)


### PR DESCRIPTION
Rails 6.1 generates a deprecation warning since connection_config will be removed from Rails 6.2.

This resolves that issue by changing the symbol where it's referenced.