### PR TITLE
Replace URI::escape which was removed in Ruby 3

### DIFF
--- a/app/views/devise_token_auth/omniauth_external_window.html.erb
+++ b/app/views/devise_token_auth/omniauth_external_window.html.erb
@@ -15,7 +15,7 @@
             Cordova / PhoneGap)
       */
 
-      var data = JSON.parse(decodeURIComponent('<%= URI::escape( @data.to_json ) %>'));
+      var data = JSON.parse(decodeURIComponent('<%= CGI::escape( @data.to_json ) %>'));
 
       window.addEventListener("message", function(ev) {
         if (ev.data === "requestCredentials") {


### PR DESCRIPTION
`URI::escape` was removed in Ruby 3.0.0. https://github.com/ruby/uri/pull/9
This PR replaces `URI::escape` with `CGI::escape`, making the library compatible with Ruby 3.