### PR TITLE
Workaround for cc-test-reporter with SimpleCov 0.18

### DIFF
--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -36,7 +36,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_4_2_mongoid_5.gemfile
+++ b/gemfiles/rails_4_2_mongoid_5.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -36,7 +36,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -36,7 +36,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1_mongoid_6.gemfile
+++ b/gemfiles/rails_5_1_mongoid_6.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_1_mongoid_7.gemfile
+++ b/gemfiles/rails_5_1_mongoid_7.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -36,7 +36,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2_mongoid_6.gemfile
+++ b/gemfiles/rails_5_2_mongoid_6.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_5_2_mongoid_7.gemfile
+++ b/gemfiles/rails_5_2_mongoid_7.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -36,7 +36,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", "< 0.18", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do

--- a/gemfiles/rails_6_0_mongoid_7.gemfile
+++ b/gemfiles/rails_6_0_mongoid_7.gemfile
@@ -35,7 +35,7 @@ end
 
 group :test do
   gem "rails-controller-testing"
-  gem "simplecov", require: false
+  gem "simplecov", "~> 0.10", "< 0.18", require: false
 end
 
 group :development do


### PR DESCRIPTION
This PR fixes the build error when using cc-test-reporter with SimpleCov 0.18.

This patch is a workaround until the following issue will be resolved.
codeclimate/test-reporter#418