### PR TITLE
fix mongoid detecting bug

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -218,13 +218,8 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def should_remove_tokens_after_password_reset?
-    if Rails::VERSION::MAJOR <= 5 ||defined?(Mongoid)
-      encrypted_password_changed? &&
+    encrypted_password_changed? &&
         DeviseTokenAuth.remove_tokens_after_password_reset
-    else
-      saved_change_to_attribute?(:encrypted_password) &&
-        DeviseTokenAuth.remove_tokens_after_password_reset
-    end
   end
 
   def remove_tokens_after_password_reset

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -218,7 +218,7 @@ module DeviseTokenAuth::Concerns::User
   end
 
   def should_remove_tokens_after_password_reset?
-    if Rails::VERSION::MAJOR <= 5 ||defined?('Mongoid')
+    if Rails::VERSION::MAJOR <= 5 ||defined?(Mongoid)
       encrypted_password_changed? &&
         DeviseTokenAuth.remove_tokens_after_password_reset
     else


### PR DESCRIPTION
## issue
This will always return string "expression" even when I don't use Mongoid.
```ruby
defined?('Mongoid')
```