### PR TITLE
Fix scope class name when setting resource by token

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -76,7 +76,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     # mitigate timing attacks by finding by uid instead of auth token
     user = uid && rc.dta_find_by(uid: uid)
-    scope = rc.to_s.underscore.to_sym
+    scope = rc.to_s.underscore.gsub('/', '_').to_sym
 
     if user && user.valid_token?(@token.token, @token.client)
       # sign_in with bypass: true will be deprecated in the next version of Devise


### PR DESCRIPTION
Hi! I'm pushing this change without tests just to make sure the change makes sense before actually writing the specs.

I noticed the scope name is no properly set for models that exist within another model like `Users::Customer`. I see in places like [this](https://github.com/lynndylanhurley/devise_token_auth/blob/63cc1be039925615b6d1adb4d41bddf613b03e30/lib/devise_token_auth/rails/routes.rb#L20) that you actually handle that so not doing the same in the concern was probably just overlooked.

The current `scope = rc.to_s.underscore.to_sym` will generate `users/customer` as the scope name and this is a problem as the devise mapping name will be `users_customer`. The problem with this and the reason I saw this is that when using the `sign_in` method, warden will try to serialize the resource and when trying to do so [here](https://github.com/heartcombo/devise/blob/5d5636f03ac19e8188d99c044d4b5e90124313af/lib/devise/controllers/sign_in_out.rb#L68) and [here](https://github.com/wardencommunity/warden/blob/8b44aa4dd8ff4bfcc0e7257dea095789ffb58690/lib/warden/session_serializer.rb#L25) it will fail to find the custom devise serializer for the model and will simply use `serialize`. This can (and has happened to me) lead to cookie overflows as the model can be potentially big default serialization will include all columns in the serialized string.

Let me know what you think, happy to add specs if you think this is fine, but I guess I would have to add another model scoped to a module in order to do so.