### PR TITLE
Fix unescape and keyword parameters warning

### DIFF
--- a/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/devise_token_auth/omniauth_callbacks_controller_test.rb
@@ -18,7 +18,7 @@ class OmniauthTest < ActionDispatch::IntegrationTest
 
   def get_parsed_data_json
     encoded_json_data = @response.body.match(/var data \= JSON.parse\(decodeURIComponent\(\'(.+)\'\)\)\;/)[1]
-    JSON.parse(URI.unescape(encoded_json_data))
+    JSON.parse(CGI.unescape(encoded_json_data))
   end
 
   describe 'success callback' do

--- a/test/controllers/overrides/confirmations_controller_test.rb
+++ b/test/controllers/overrides/confirmations_controller_test.rb
@@ -38,7 +38,7 @@ class Overrides::ConfirmationsControllerTest < ActionDispatch::IntegrationTest
       override_proof_str = '(^^,)'
 
       # ensure present in redirect URL
-      override_proof_param = URI.unescape(response.headers['Location']
+      override_proof_param = CGI.unescape(response.headers['Location']
                                 .match(/override_proof=([^&]*)&/)[1])
 
       assert_equal override_proof_str, override_proof_param

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,7 +116,7 @@ module Rails
         %w[get post patch put head delete get_via_redirect post_via_redirect].each do |method|
           define_method(method) do |path_or_action, **args|
             if Rails::VERSION::MAJOR >= 5
-              super path_or_action, args
+              super path_or_action, **args
             else
               super path_or_action, args[:params], args[:headers]
             end


### PR DESCRIPTION
I fixed the two warnings.

**1 warning: URI.unescape is obsolete**

I replaced `URI.unescape` with `CGI.unescape`.
https://docs.rubocop.org/rubocop/cops_lint.html#examples-111

**2 warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call**

I added `**`.