### PR TITLE
Turn email validation process into class method

### DIFF
--- a/app/validators/devise_token_auth_email_validator.rb
+++ b/app/validators/devise_token_auth_email_validator.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 class DeviseTokenAuthEmailValidator < ActiveModel::EachValidator
+  EMAIL_REGEXP = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
+  class << self
+    def validate?(email)
+      email =~ EMAIL_REGEXP
+    end
+  end
+
   def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless DeviseTokenAuthEmailValidator.validate?(value)
       record.errors.add(attribute, email_invalid_message)
     end
   end


### PR DESCRIPTION
# Overview
Currently, in order to validate an email address, you need to create a resource class and then run validate?

However, there are times when you just want to verify the email address before creating the resource class.

# Changes
When you only want to verify email addresses,

Now:

```ruby
def create
  user = User.new(user_params)
  user.validate?
  
  if user.errors.messages[:email].present?
    return head :bad_request
  end

  ...
end
```

or

```ruby
def create  
  # Copy the regular expression directly from DeviseTokenAuthEmailValidator
  # Duplication of regular expression definitions occurs
  unless user_params[:email] =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
    return head :bad_request
  end

  ...
end
```

After:

```
def create
  unless DeviseTokenAuthEmailValidator.validate?(user_params[:email])
    return head :bad_request
  end

  ...
end
```

# Test
Guaranteed to work with the following tests
https://github.com/lynndylanhurley/devise_token_auth/blob/master/test/models/user_test.rb#L24-L38