### PR TITLE
Increase required ruby version to 2.3

### DIFF
--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
   s.test_files.reject! { |file| file.match(/[.log|.sqlite3]$/) }
 
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency 'rails', '>= 4.2.0', '< 6.2'
   s.add_dependency 'devise', '> 3.5.2', '< 5'


### PR DESCRIPTION
Usage of the safe operator `&` was introduced in ruby 2.3 and new code uses that

Here's a build as reference where the latest version of this gem fails when running Ruby 2.2

https://app.circleci.com/pipelines/github/graphql-devise/graphql_devise/86/workflows/0b0b19ab-1ddc-4917-a092-e5285177f791/jobs/5379