### PR TITLE
wrap creation and save of token in a transaction

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -26,10 +26,9 @@ module DeviseTokenAuth
         if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
           return render_create_error_bad_credentials
         end
-        @resource.with_lock do
-          @token = @resource.create_token
-          @resource.save
-        end
+
+        create_and_assign_token
+
         sign_in(:user, @resource, store: false, bypass: false)
 
         yield @resource if block_given?
@@ -133,6 +132,18 @@ module DeviseTokenAuth
 
     def resource_params
       params.permit(*params_for_resource(:sign_in))
+    end
+
+    def create_and_assign_token
+      if @resource.respond_to?(:with_lock)
+        @resource.with_lock do
+          @token = @resource.create_token
+          @resource.save!
+        end
+      else
+        @token = @resource.create_token
+        @resource.save!
+      end
     end
   end
 end

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -26,9 +26,10 @@ module DeviseTokenAuth
         if (@resource.respond_to?(:valid_for_authentication?) && !@resource.valid_for_authentication? { valid_password }) || !valid_password
           return render_create_error_bad_credentials
         end
-        @token = @resource.create_token
-        @resource.save
-
+        @resource.with_lock do
+          @token = @resource.create_token
+          @resource.save
+        end
         sign_in(:user, @resource, store: false, bypass: false)
 
         yield @resource if block_given?


### PR DESCRIPTION
this will reload the record and lock the row in the DB so we
only ever have one request accessing the record at one time.

this prevents multiple requests overwriting the tokens.

We tested this in our app with 10 threads accessing at the "same time" and could show the problem and that it disappears with the fix.
if you have any idea how i can do this with a test, please advise.

Also this will most likely not work with MongoId?

fixes #1497 
