### PR TITLE
Fix callback if migrations fails

### DIFF
--- a/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
+++ b/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb
@@ -4,12 +4,12 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
   extend ActiveSupport::Concern
 
   included do
-    validates :email, presence: true,if: :email_provider?
-    validates :email, :devise_token_auth_email => true, allow_nil: true, allow_blank: true, if: :email_provider?
-    validates_presence_of :uid, unless: :email_provider?
+    validates :email, presence: true, if: lambda { uid_and_provider_defined? && email_provider? }
+    validates :email, :devise_token_auth_email => true, allow_nil: true, allow_blank: true, if: lambda { uid_and_provider_defined? && email_provider? }
+    validates_presence_of :uid, if: lambda { uid_and_provider_defined? && !email_provider? }
 
     # only validate unique emails among email registration users
-    validates :email, uniqueness: { case_sensitive: false, scope: :provider }, on: :create, if: :email_provider?
+    validates :email, uniqueness: { case_sensitive: false, scope: :provider }, on: :create, if: lambda { uid_and_provider_defined? && email_provider? }
 
     # keep uid in sync with email
     before_save :sync_uid
@@ -17,6 +17,10 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
   end
 
   protected
+
+  def uid_and_provider_defined?
+    defined?(provider) && defined?(uid)
+  end
 
   def email_provider?
     provider == 'email'
@@ -26,6 +30,6 @@ module DeviseTokenAuth::Concerns::UserOmniauthCallbacks
     unless self.new_record?
       return if devise_modules.include?(:confirmable) && !@bypass_confirmation_postpone && postpone_email_change?
     end
-    self.uid = email if email_provider?
+    self.uid = email if uid_and_provider_defined? && email_provider?
   end
 end


### PR DESCRIPTION
To  prevent failed migration, when you insert this gem in existing project and you want to run: 
```
rake db:create && rake db:migrate
```
Migrations fail because of uid and provider attributes that do not exist yet in the first migrations (past migrations).