### PR TITLE
Fix the doc missing configure devise mail sender

### DIFF
--- a/docs/config/email_auth.md
+++ b/docs/config/email_auth.md
@@ -12,5 +12,15 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = { address: 'your-dev-host.dev', port: 1025 }
 end
 ~~~
+You also may want to configure `mail_sender` at devise initializer if you don't use your own mailer class
+##### devise configuration:
+~~~ruby
+# config/initializers/devise.rb
+Devise.setup do |config|
+  config.mailer_sender = "example@example.com"
+end
+~~~
+
+
 
 If you wish to send custom e-mails instead of using the default devise templates, you can [do that too](/docs/usage/overrides.md#email-template-overrides).

--- a/docs/config/email_auth.md
+++ b/docs/config/email_auth.md
@@ -21,6 +21,4 @@ Devise.setup do |config|
 end
 ~~~
 
-
-
 If you wish to send custom e-mails instead of using the default devise templates, you can [do that too](/docs/usage/overrides.md#email-template-overrides).


### PR DESCRIPTION
I had to add 
```ruby
# config/initializers/devise.rb
Devise.setup do |config|
  config.mailer_sender = "example@example.com"
end
``` 
In order to make my app send emails successfully