### PR TITLE
add `previous_token`

### DIFF
--- a/test/controllers/demo_mang_controller_test.rb
+++ b/test/controllers/demo_mang_controller_test.rb
@@ -235,7 +235,7 @@ class DemoMangControllerTest < ActionDispatch::IntegrationTest
             @resource.reload
             age_token(@resource, @client_id)
 
-            # use expired auth header
+            # use previous auth header
             get '/demo/members_only_mang',
                 params: {},
                 headers: @auth_headers
@@ -244,38 +244,67 @@ class DemoMangControllerTest < ActionDispatch::IntegrationTest
             @second_user = assigns(:resource)
             @second_access_token = response.headers['access-token']
             @second_response_status = response.status
+
+            @resource.reload
+            age_token(@resource, @client_id)
+
+            # use expired auth headers
+            get '/demo/members_only_mang',
+                params: {},
+                headers: @auth_headers
+
+            @third_is_batch_request = assigns(:is_batch_request)
+            @third_user = assigns(:resource)
+            @third_access_token = response.headers['access-token']
+            @third_response_status = response.status
           end
 
           it 'should allow the first request through' do
             assert_equal 200, @first_response_status
           end
 
+          it 'should allow the second request through' do
+            assert_equal 200, @second_response_status
+          end
+
           it 'should not allow the second request through' do
-            assert_equal 401, @second_response_status
+            assert_equal 401, @third_response_status
           end
 
           it 'should not treat first request as batch request' do
-            refute @second_is_batch_request
-          end
-
-          it 'should return auth headers from the first request' do
-            assert @first_access_token
+            refute @first_is_batch_request
           end
 
           it 'should not treat second request as batch request' do
             refute @second_is_batch_request
           end
 
-          it 'should not return auth headers from the second request' do
-            refute @second_access_token
+          it 'should not treat third request as batch request' do
+            refute @third_is_batch_request
+          end
+
+          it 'should return auth headers from the first request' do
+            assert @first_access_token
+          end
+
+          it 'should return auth headers from the second request' do
+            assert @second_access_token
+          end
+
+          it 'should not return auth headers from the third request' do
+            refute @third_access_token
           end
 
           it 'should define user during first request' do
             assert @first_user
           end
 
-          it 'should not define user during second request' do
-            refute @second_user
+          it 'should define user during second request' do
+            assert @second_user
+          end
+
+          it 'should not define user during third request' do
+            refute @third_user
           end
         end
       end

--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -265,7 +265,7 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
             @resource.reload
             age_token(@resource, @client_id)
 
-            # use expired auth header
+            # use previous auth header
             get '/demo/members_only',
                 params: {},
                 headers: @auth_headers

--- a/test/controllers/demo_user_controller_test.rb
+++ b/test/controllers/demo_user_controller_test.rb
@@ -274,38 +274,67 @@ class DemoUserControllerTest < ActionDispatch::IntegrationTest
             @second_user = assigns(:resource)
             @second_access_token = response.headers['access-token']
             @second_response_status = response.status
+
+            @resource.reload
+            age_token(@resource, @client_id)
+
+            # use expired auth headers
+            get '/demo/members_only_mang',
+                params: {},
+                headers: @auth_headers
+
+            @third_is_batch_request = assigns(:is_batch_request)
+            @third_user = assigns(:resource)
+            @third_access_token = response.headers['access-token']
+            @third_response_status = response.status
           end
 
           it 'should allow the first request through' do
             assert_equal 200, @first_response_status
           end
 
+          it 'should allow the second request through' do
+            assert_equal 200, @second_response_status
+          end
+
           it 'should not allow the second request through' do
-            assert_equal 401, @second_response_status
+            assert_equal 401, @third_response_status
           end
 
           it 'should not treat first request as batch request' do
-            refute @second_is_batch_request
-          end
-
-          it 'should return auth headers from the first request' do
-            assert @first_access_token
+            refute @first_is_batch_request
           end
 
           it 'should not treat second request as batch request' do
             refute @second_is_batch_request
           end
 
-          it 'should not return auth headers from the second request' do
-            refute @second_access_token
+          it 'should not treat third request as batch request' do
+            refute @third_is_batch_request
+          end
+
+          it 'should return auth headers from the first request' do
+            assert @first_access_token
+          end
+
+          it 'should return auth headers from the second request' do
+            assert @second_access_token
+          end
+
+          it 'should not return auth headers from the third request' do
+            refute @third_access_token
           end
 
           it 'should define user during first request' do
             assert @first_user
           end
 
-          it 'should not define user during second request' do
-            refute @second_user
+          it 'should define user during second request' do
+            assert @second_user
+          end
+
+          it 'should not define user during third request' do
+            refute @third_user
           end
         end
       end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -76,6 +76,28 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'previous token' do
+      before do
+        @resource = create(:user, :confirmed)
+
+        @auth_headers1 = @resource.create_new_auth_token
+      end
+
+      test 'should properly indicate whether previous token is current' do
+        assert @resource.token_is_current?(@auth_headers1['access-token'], @auth_headers1['client'])
+        # create another token, emulating a new request
+        @auth_headers2 = @resource.create_new_auth_token
+
+        # should work for previous token
+        assert @resource.token_is_current?(@auth_headers1['access-token'], @auth_headers1['client'])
+        # should work for latest token as well
+        assert @resource.token_is_current?(@auth_headers2['access-token'], @auth_headers2['client'])
+
+        # after using latest token, previous token should not work
+        assert @resource.token_is_current?(@auth_headers1['access-token'], @auth_headers1['client'])
+      end
+    end
+
     describe 'expired tokens are destroyed on save' do
       before do
         @resource = create(:user, :confirmed)


### PR DESCRIPTION
Closes #1232

Solves the issue mentioned in #1232 

Implements the solution mentioned in https://github.com/lynndylanhurley/devise_token_auth/issues/1232#issuecomment-435022610
and basically copied from the PR #1315 

Added tests for the same, updated a few comments to separate keyword `previous` from `last`

(opened this PR as #1315  seems to be stale and this is a critical issue, at least for our use case)