### PR TITLE
Fix Paranoid Status Codes

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -62,7 +62,7 @@ module DeviseTokenAuth
 
     def render_not_found_error
       if Devise.paranoid
-        render_error(404, I18n.t('devise_token_auth.confirmations.sended_paranoid'))
+        render_create_success
       else
         render_error(404, I18n.t('devise_token_auth.confirmations.user_not_found', email: @email))
       end

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -182,7 +182,7 @@ module DeviseTokenAuth
 
     def render_not_found_error
       if Devise.paranoid
-        render_error(404, I18n.t('devise_token_auth.passwords.sended_paranoid'))
+        render_create_success
       else
         render_error(404, I18n.t('devise_token_auth.passwords.user_not_found', email: @email))
       end

--- a/app/controllers/devise_token_auth/unlocks_controller.rb
+++ b/app/controllers/devise_token_auth/unlocks_controller.rb
@@ -80,7 +80,7 @@ module DeviseTokenAuth
 
     def render_not_found_error
       if Devise.paranoid
-        render_error(404, I18n.t('devise_token_auth.unlocks.sended_paranoid'))
+        render_create_success
       else
         render_error(404, I18n.t('devise_token_auth.unlocks.user_not_found', email: @email))
       end

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -171,21 +171,30 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
             test 'response should contain message' do
               assert_equal @data['message'], I18n.t('devise_token_auth.confirmations.sended_paranoid', email: @resource.email)
             end
+
+            test 'response should return success status' do
+              assert_equal 200, response.status
+            end
           end
 
           describe 'on failure' do
             before do
               swap Devise, paranoid: true do
+                @email = 'chester@cheet.ah'
                 post :create,
-                     params: { email: 'chester@cheet.ah',
+                     params: { email: @email,
                                redirect_url: @redirect_url },
                      xhr: true
                 @data = JSON.parse(response.body)
               end
             end
 
-            test 'response should contain errors' do
-              assert_equal @data['errors'], [I18n.t('devise_token_auth.confirmations.sended_paranoid')]
+            test 'response should not contain errors' do
+              assert_equal @data['message'], I18n.t('devise_token_auth.confirmations.sended_paranoid', email: @email)
+            end
+
+            test 'response should return success status' do
+              assert_equal 200, response.status
             end
           end
         end

--- a/test/controllers/devise_token_auth/passwords_controller_test.rb
+++ b/test/controllers/devise_token_auth/passwords_controller_test.rb
@@ -116,14 +116,14 @@ class DeviseTokenAuth::PasswordsControllerTest < ActionController::TestCase
               end
             end
 
-            test 'unknown user should return 404' do
-              assert_equal 404, response.status
+            test 'response should return success status' do
+              assert_equal 200, response.status
             end
 
-            test 'errors should be returned' do
-              assert @data['errors']
-              assert_equal @data['errors'],
-              [I18n.t('devise_token_auth.passwords.sended_paranoid')]
+            test 'response should contain message' do
+              assert_equal \
+                @data['message'],
+              I18n.t('devise_token_auth.passwords.sended_paranoid')
             end
           end
         end

--- a/test/controllers/devise_token_auth/unlocks_controller_test.rb
+++ b/test/controllers/devise_token_auth/unlocks_controller_test.rb
@@ -81,17 +81,19 @@ class DeviseTokenAuth::UnlocksControllerTest < ActionController::TestCase
             end
           end
 
-          test 'unknown user should return 404' do
-            assert_equal 404, response.status
+          test 'should always return success' do
+            assert_equal 200, response.status
           end
 
-          test 'errors should be returned' do
-            assert @data['errors']
-            assert_equal @data['errors'], [I18n.t('devise_token_auth.unlocks.sended_paranoid')]
+          test 'errors should not be returned' do
+            assert @data['success']
+            assert_equal \
+              @data['message'],
+            I18n.t('devise_token_auth.unlocks.sended_paranoid')
           end
         end
 
-        describe 'successfully requested unlock' do
+        describe 'successfully requested unlock without paranoid mode' do
           before do
             post :create, params: { email: @resource.email }
 
@@ -100,6 +102,26 @@ class DeviseTokenAuth::UnlocksControllerTest < ActionController::TestCase
 
           test 'response should not contain extra data' do
             assert_nil @data['data']
+          end
+        end
+
+        describe 'successfully requested unlock with paranoid mode' do
+          before do
+            swap Devise, paranoid: true do
+              post :create, params: { email: @resource.email }
+              @data = JSON.parse(response.body)
+            end
+          end
+
+          test 'should always return success' do
+            assert_equal 200, response.status
+          end
+
+          test 'errors should not be returned' do
+            assert @data['success']
+            assert_equal \
+              @data['message'],
+            I18n.t('devise_token_auth.unlocks.sended_paranoid')
           end
         end
 


### PR DESCRIPTION
Changes to ensure that if the `Devise.paranoid` option is enabled, an OK message and status code is always returned regardless of whether the operation actually failed.

Fixes #1510 