### PR TITLE
Set cookie token on omniauth success to avoid having to store the scraped query param token in the client

### DIFF
--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -59,6 +59,14 @@ module DeviseTokenAuth
       set_token_on_resource
       create_auth_params
 
+      # If using a cookie to transport the token then we can set that cookie now, rather than making
+      # the client scrape the token from query params to then send in the initial validate_token request.
+      # TODO: We should be able to stop exposing the token in query params when using a cookie
+      if DeviseTokenAuth.cookie_enabled
+        auth_header = @resource.build_auth_header(@token.token, @token.client)
+        cookies[DeviseTokenAuth.cookie_name] = DeviseTokenAuth.cookie_attributes.merge(value: auth_header.to_json)
+      end
+
       if confirmable_enabled?
         # don't send confirmation email!!!
         @resource.skip_confirmation!


### PR DESCRIPTION
In #1453 we added support for sending and receiving the auth token as a cookie. We're currently working on a de-angularized version of ng-token-auth with cookie support, which means we don't need to store the token in client storage anymore. But I realized that the OAuth flow still requires client storage because the token is scraped from query params, temporarily stored in client storage, then sent to the `validate_token` call, where a cookie is created. I realized that we could instead just create the cookie immediately in the same place that we're creating the query params in order to avoid having to leak the token in client storage just for that small initial period.