### PR TITLE
Set cookie token immediately in reset password and OmniAuth success flows

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -83,5 +83,14 @@ module DeviseTokenAuth
         I18n.t("devise_token_auth.#{name}.sended", email: email)
       end
     end
+
+    # When using a cookie to transport the auth token we can set it immediately in flows such as
+    # reset password and OmniAuth success, rather than making the client scrape the token from
+    # query params (to then send in the initial validate_token request).
+    # TODO: We should be able to stop exposing the token in query params when this method is used
+    def set_token_in_cookie(resource, token)
+      auth_header = resource.build_auth_header(token.token, token.client)
+      cookies[DeviseTokenAuth.cookie_name] = DeviseTokenAuth.cookie_attributes.merge(value: auth_header.to_json)
+    end
   end
 end

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -70,6 +70,10 @@ module DeviseTokenAuth
 
       yield @resource if block_given?
 
+      if DeviseTokenAuth.cookie_enabled
+        set_token_in_cookie(@resource, @token)
+      end
+
       render_data_or_redirect('deliverCredentials', @auth_params.as_json, @resource.as_json)
     end
 

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -51,6 +51,10 @@ module DeviseTokenAuth
         if require_client_password_reset_token?
           redirect_to DeviseTokenAuth::Url.generate(@redirect_url, reset_password_token: resource_params[:reset_password_token])
         else
+          if DeviseTokenAuth.cookie_enabled
+            set_token_in_cookie(@resource, token)
+          end
+
           redirect_header_options = { reset_password: true }
           redirect_headers = build_redirect_headers(token.token,
                                                     token.client,


### PR DESCRIPTION
In #1453 we added support for sending and receiving the auth token as a cookie. We're currently working on a de-angularized version of [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) with cookie support, which means we don't need to store the token in client storage anymore. But I realized that the reset password link and OmniAuth success flows still requires client storage because the token is scraped from query params, temporarily stored in client storage, then sent to the `validate_token` call, where a cookie is then initially created. I realized that we could instead just create the cookie immediately in the same place that we're creating the query params in order to avoid having to leak the token in client storage just for that small initial period.