### PR TITLE
Fixed ja.yml because CI failed.

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,7 +21,7 @@ ja:
       missing_redirect_url: "リダイレクト URL が与えられていません。"
       not_allowed_redirect_url: "'%{redirect_url}' へのリダイレクトは許可されていません。"
       sended: "'%{email}' にパスワードリセットの案内が送信されました。"
-      sended_paranoid: ""すでにメールアドレスがデータベースに登録されている場合、 数分後にパスワード再発行用のリンクを記載したメールをお送りします。"
+      sended_paranoid: "すでにメールアドレスがデータベースに登録されている場合、 数分後にパスワード再発行用のリンクを記載したメールをお送りします。"
       user_not_found: "メールアドレス '%{email}' のユーザーが見つかりません。"
       password_not_required: "このアカウントはパスワードを要求していません。'%{provider}' を利用してログインしてください。"
       missing_passwords: "'Password', 'Password confirmation' パラメータが与えられていません。"


### PR DESCRIPTION
The ja.yml was failing to load because it started with two double quotes!


~...But do you know why these are failing in CI?~
- ~Test / test (2.7, gemfiles/rails_5_2.gemfile, postgresql, active_record)~
- ~Test / test (2.5, gemfiles/rails_5_1.gemfile, mysql, active_record) (pull_request)~