### PR TITLE
Add custom uid reference

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -32,6 +32,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     # gets the headers names, which was set in the initialize file
     uid_name = DeviseTokenAuth.headers_names[:'uid']
+    other_uid_name = DeviseTokenAuth.other_uid && DeviseTokenAuth.headers_names[DeviseTokenAuth.other_uid.to_sym]
     access_token_name = DeviseTokenAuth.headers_names[:'access-token']
     client_name = DeviseTokenAuth.headers_names[:'client']
     authorization_name = DeviseTokenAuth.headers_names[:"authorization"]
@@ -50,6 +51,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     # parse header for values necessary for authentication
     uid              = request.headers[uid_name] || params[uid_name] || parsed_auth_cookie[uid_name] || decoded_authorization_token[uid_name]
+    other_uid        = other_uid_name && request.headers[other_uid_name] || params[other_uid_name] || parsed_auth_cookie[other_uid_name]
     @token           = DeviseTokenAuth::TokenFactory.new unless @token
     @token.token     ||= request.headers[access_token_name] || params[access_token_name] || parsed_auth_cookie[access_token_name] || decoded_authorization_token[access_token_name]
     @token.client ||= request.headers[client_name] || params[client_name] || parsed_auth_cookie[client_name] || decoded_authorization_token[client_name]
@@ -79,7 +81,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     end
 
     # mitigate timing attacks by finding by uid instead of auth token
-    user = uid && rc.dta_find_by(uid: uid)
+    user = (uid && rc.dta_find_by(uid: uid)) || (other_uid && rc.dta_find_by("#{DeviseTokenAuth.other_uid}": other_uid))
     scope = rc.to_s.underscore.to_sym
 
     if user && user.valid_token?(@token.token, @token.client)

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -30,7 +30,8 @@ module DeviseTokenAuth
                  :cookie_attributes,
                  :bypass_sign_in,
                  :send_confirmation_email,
-                 :require_client_password_reset_token
+                 :require_client_password_reset_token,
+                 :other_uid
 
   self.change_headers_on_each_request       = true
   self.max_number_of_devices                = 10
@@ -57,6 +58,7 @@ module DeviseTokenAuth
   self.bypass_sign_in                       = true
   self.send_confirmation_email              = false
   self.require_client_password_reset_token  = false
+  self.other_uid                            = nil
 
   def self.setup(&block)
     yield self

--- a/lib/generators/devise_token_auth/templates/devise_token_auth.rb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth.rb
@@ -48,6 +48,9 @@ DeviseTokenAuth.setup do |config|
   #                        :'uid' => 'uid',
   #                        :'token-type' => 'token-type' }
 
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can
   # do so by enabling this flag. NOTE: This feature is highly experimental!


### PR DESCRIPTION
Adds the possibility to lookup for user by custom column, other than the default `:uid`. This would provide support for working with multiple databases, since uid does not ensure uniqueness in such case.