### PR TITLE
Avoid raising a RoutingError when confirming a user twice

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -26,7 +26,7 @@ module DeviseTokenAuth
 
         redirect_to(redirect_to_link)
       else
-        raise ActionController::RoutingError, 'Not Found'
+        redirect_to DeviseTokenAuth::Url.generate(redirect_url, account_confirmation_success: false)
       end
     end
 


### PR DESCRIPTION
A simple PR to avoid raising a RoutingError when confirming a user twice or when the token has expired.
Please check it out.

#1123
#1110
#1316 
