### PR TITLE
Allow omniauth redirect post method

### DIFF
--- a/lib/devise_token_auth/rails/routes.rb
+++ b/lib/devise_token_auth/rails/routes.rb
@@ -65,8 +65,8 @@ module ActionDispatch::Routing
 
           # omniauth routes. only define if omniauth is installed and not skipped.
           if defined?(::OmniAuth) && !opts[:skip].include?(:omniauth_callbacks)
-            match "#{full_path}/failure",             controller: omniauth_ctrl, action: 'omniauth_failure', via: [:get]
-            match "#{full_path}/:provider/callback",  controller: omniauth_ctrl, action: 'omniauth_success', via: [:get]
+            match "#{full_path}/failure",             controller: omniauth_ctrl, action: 'omniauth_failure', via: [:get, :post]
+            match "#{full_path}/:provider/callback",  controller: omniauth_ctrl, action: 'omniauth_success', via: [:get, :post]
 
             match "#{DeviseTokenAuth.omniauth_prefix}/:provider/callback", controller: omniauth_ctrl, action: 'redirect_callbacks', via: [:get, :post]
             match "#{DeviseTokenAuth.omniauth_prefix}/failure", controller: omniauth_ctrl, action: 'omniauth_failure', via: [:get, :post]


### PR DESCRIPTION
Some time ago, the POST omniauth redirect was introduced https://github.com/lynndylanhurley/devise_token_auth/pull/1509/files#diff-e297b1cbec8129624683adca1209383ebe6cbc3bfeebae01e590530e597dc062R26, but that actually doesn't work, because no POST redirect route is available.