### PR TITLE
Update initializer template

### DIFF
--- a/lib/generators/devise_token_auth/templates/devise_token_auth.rb
+++ b/lib/generators/devise_token_auth/templates/devise_token_auth.rb
@@ -42,11 +42,14 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  # config.headers_names = {
+  #   :'authorization' => 'Authorization',
+  #   :'access-token' => 'access-token',
+  #   :'client' => 'client',
+  #   :'expiry' => 'expiry',
+  #   :'uid' => 'uid',
+  #   :'token-type' => 'token-type'
+  # }
 
   # Makes it possible to use custom uid column
   # config.other_uid = "foo"


### PR DESCRIPTION
Add `authorization` key in the `headers_name` necessary to "fix" the error "NoMethodError: undefined method `downcase' for nil:NilClass".

Ref: #1540 