### PR TITLE
Fix unpermitted parameters warning

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -131,7 +131,7 @@ module DeviseTokenAuth
     private
 
     def resource_params
-      params.permit(*params_for_resource(:sign_in))
+      params.require(:session).permit(*params_for_resource(:sign_in))
     end
 
     def create_and_assign_token


### PR DESCRIPTION
### WHY are these changes introduced?

[Rails 7 provides context when logging unpermitted parameters](https://blog.saeloun.com/2021/06/16/rails-7-provides-context-when-logging-unpermitted-parameters.html)

### WHAT is this pull request doing?

Permit `session `parameter

### Screenshots
![image](https://user-images.githubusercontent.com/69775411/207890780-ed5cbd3d-ef60-4483-87d8-3a1a1589649f.png)
