### PR TITLE
Allow extra data for new token creation method

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -166,14 +166,15 @@ module DeviseTokenAuth::Concerns::User
   end
 
   # update user's auth token (should happen on each request)
-  def create_new_auth_token(client = nil)
+  def create_new_auth_token(client = nil, extra_data: {})
     now = Time.zone.now
 
     token = create_token(
       client: client,
       previous_token: tokens.fetch(client, {})['token'],
       last_token: tokens.fetch(client, {})['previous_token'],
-      updated_at: now
+      updated_at: now,
+      **extra_data
     )
 
     update_auth_header(token.token, token.client)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -76,6 +76,23 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'token with extra data' do
+      let(:extra_data) { { scope: "write:profile" } }
+      before do
+        @resource = create(:user, :confirmed)
+
+        @auth_headers = @resource.create_new_auth_token(extra_data)
+
+        @token     = @auth_headers['access-token']
+        @client_id = @auth_headers['client']
+      end
+
+      test 'should extra data will be stored with token info' do
+        assert @resource.token_is_current?(@token, @client_id)
+        assert @resource.tokens[@client_id]["scope"], extra_data["scope"]
+      end
+    end
+
     describe 'previous token' do
       before do
         @resource = create(:user, :confirmed)


### PR DESCRIPTION
`create_token` method is allowing extra data but, `create_new_auth_token` is blocking that feature.
And this will help users of this gem define their own logic with extra data.