### PR TITLE
🐛 Not update cookies when is a batch request

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -154,8 +154,8 @@ module DeviseTokenAuth::Concerns::SetUserByToken
       # update the response header
       response.headers.merge!(_auth_header_from_batch_request)
 
-      # set a server cookie if configured
-      if DeviseTokenAuth.cookie_enabled
+      # set a server cookie if configured and is not a batch request
+      if DeviseTokenAuth.cookie_enabled && !@is_batch_request
         set_cookie(_auth_header_from_batch_request)
       end
     end # end lock

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -22,7 +22,7 @@ module DeviseTokenAuth
           redirect_to_link = signed_in_resource.build_auth_url(redirect_url, redirect_headers)
         else
           redirect_to_link = DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
-       end
+        end
 
         redirect_to(redirect_to_link)
       else

--- a/test/controllers/devise_token_auth/confirmations_controller_test.rb
+++ b/test/controllers/devise_token_auth/confirmations_controller_test.rb
@@ -202,9 +202,12 @@ class DeviseTokenAuth::ConfirmationsControllerTest < ActionController::TestCase
 
       describe 'failure' do
         test 'user should not be confirmed' do
-          assert_raises(ActionController::RoutingError) do
-            get :show, params: { confirmation_token: 'bogus' }
-          end
+          get :show,
+              params: { confirmation_token: 'bogus',
+                        redirect_url: @redirect_url }
+
+          assert_redirected_to(/^#{@redirect_url}/)
+
           @resource = assigns(:resource)
           refute @resource.confirmed?
         end


### PR DESCRIPTION
Due to the batch requests approach, when this occurs the header has a blank token for the other requests and with that the current logic invalidates the cookie, as it is automatically updated by the back-end without any control from the client (browser) , for those cases due to ignore any change in them to keep what was received in the last valid request (in theory the first received that was not treated as a batch).