### PR TITLE
chore: add vanilla-token-auth to client list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Also, it maintains a session for each client/device, so you can have as many ses
 ## Main features
 
 * Seamless integration with:
+  * [vanilla-token-auth](https://github.com/theblang/vanilla-token-auth) for an unopinionated client
   * [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) for [AngularJS](https://github.com/angular/angular.js)
   * [Angular-Token](https://github.com/neroniaky/angular-token) for [Angular](https://github.com/angular/angular)
   * [redux-token-auth](https://github.com/kylecorbelli/redux-token-auth) for [React with Redux](https://github.com/reactjs/react-redux)

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Also, it maintains a session for each client/device, so you can have as many ses
 ## Main features
 
 * Seamless integration with:
-  * [vanilla-token-auth](https://github.com/theblang/vanilla-token-auth) for an unopinionated client
   * [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) for [AngularJS](https://github.com/angular/angular.js)
   * [Angular-Token](https://github.com/neroniaky/angular-token) for [Angular](https://github.com/angular/angular)
   * [redux-token-auth](https://github.com/kylecorbelli/redux-token-auth) for [React with Redux](https://github.com/reactjs/react-redux)
   * [jToker](https://github.com/lynndylanhurley/j-toker) for [jQuery](https://jquery.com/)
+  * [vanilla-token-auth](https://github.com/theblang/vanilla-token-auth) for an unopinionated client
 * Oauth2 authentication using [OmniAuth](https://github.com/intridea/omniauth).
 * Email authentication using [Devise](https://github.com/plataformatec/devise), including:
   * User registration, update and deletion


### PR DESCRIPTION
We're in the process of converting AngularJS code to React and needed a client that could interface with Devise Token Auth in both contexts, so we built this vanilla client based on [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth). I thought it might be helpful to others, so I'm adding it to the client list in the documentation.