### PR TITLE
Method sign_in with wrong parameters

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -29,7 +29,7 @@ module DeviseTokenAuth
 
         create_and_assign_token
 
-        sign_in(:user, @resource, store: false, bypass: false)
+        sign_in(@resource, scope: :user, store: false, bypass: false)
 
         yield @resource if block_given?
 


### PR DESCRIPTION
Sometimes it might cause "undefined method 'devise_modules' for :user:Symbol"

https://github.com/devise-security/devise-security/blob/8df7d64483df8cf8de4997ec1f5ffcad0c542458/lib/devise-security/hooks/session_limitable.rb#L7

https://github.com/heartcombo/devise/blob/main/lib/devise/controllers/sign_in_out.rb#L33
