### PR TITLE
dependencies/dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "master"


### PR DESCRIPTION
#### Description

Setting up dependabot could keep the libraries up to date.
This PR sets up dependabot to keep dependencies up to date