### PR TITLE
add redirect_to options for rails7 allow_other_host

### DIFF
--- a/app/controllers/devise_token_auth/application_controller.rb
+++ b/app/controllers/devise_token_auth/application_controller.rb
@@ -84,6 +84,10 @@ module DeviseTokenAuth
       end
     end
 
+    def redirect_options
+      {}
+    end
+
     # When using a cookie to transport the auth token we can set it immediately in flows such as
     # reset password and OmniAuth success, rather than making the client scrape the token from
     # query params (to then send in the initial validate_token request).

--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -24,7 +24,7 @@ module DeviseTokenAuth
           redirect_to_link = DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
        end
 
-        redirect_to(redirect_to_link)
+        redirect_to(redirect_to_link, redirect_options)
       else
         if redirect_url
           redirect_to DeviseTokenAuth::Url.generate(redirect_url, account_confirmation_success: false)

--- a/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise_token_auth/omniauth_callbacks_controller.rb
@@ -23,7 +23,7 @@ module DeviseTokenAuth
       session['dta.omniauth.auth'] = request.env['omniauth.auth'].except('extra')
       session['dta.omniauth.params'] = request.env['omniauth.params']
 
-      redirect_to redirect_route, status: 307
+      redirect_to redirect_route, {status: 307}.merge(redirect_options)
     end
 
     def get_redirect_route(devise_mapping)
@@ -227,7 +227,7 @@ module DeviseTokenAuth
       elsif auth_origin_url # default to same-window implementation, which forwards back to auth_origin_url
 
         # build and redirect to destination url
-        redirect_to DeviseTokenAuth::Url.generate(auth_origin_url, data.merge(blank: true))
+        redirect_to DeviseTokenAuth::Url.generate(auth_origin_url, data.merge(blank: true).merge(redirect_options))
       else
 
         # there SHOULD always be an auth_origin_url, but if someone does something silly

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -49,7 +49,8 @@ module DeviseTokenAuth
         yield @resource if block_given?
 
         if require_client_password_reset_token?
-          redirect_to DeviseTokenAuth::Url.generate(@redirect_url, reset_password_token: resource_params[:reset_password_token])
+          redirect_to DeviseTokenAuth::Url.generate(@redirect_url, reset_password_token: resource_params[:reset_password_token]),
+          redirect_options
         else
           if DeviseTokenAuth.cookie_enabled
             set_token_in_cookie(@resource, token)
@@ -60,7 +61,8 @@ module DeviseTokenAuth
                                                     token.client,
                                                     redirect_header_options)
           redirect_to(@resource.build_auth_url(@redirect_url,
-                                               redirect_headers))
+                                               redirect_headers),
+                                               redirect_options)
         end
       else
         render_edit_error

--- a/app/controllers/devise_token_auth/unlocks_controller.rb
+++ b/app/controllers/devise_token_auth/unlocks_controller.rb
@@ -44,7 +44,8 @@ module DeviseTokenAuth
                                                   token.client,
                                                   redirect_header_options)
         redirect_to(@resource.build_auth_url(after_unlock_path_for(@resource),
-                                             redirect_headers))
+                                             redirect_headers),
+                                             redirect_options)
       else
         render_show_error
       end

--- a/test/dummy/app/controllers/overrides/confirmations_controller.rb
+++ b/test/dummy/app/controllers/overrides/confirmations_controller.rb
@@ -19,7 +19,8 @@ module Overrides
                                                   redirect_header_options)
 
         redirect_to(@resource.build_auth_url(params[:redirect_url],
-                                             redirect_headers))
+                                             redirect_headers),
+                                             redirect_options)
       else
         raise ActionController::RoutingError, 'Not Found'
       end

--- a/test/dummy/app/controllers/overrides/passwords_controller.rb
+++ b/test/dummy/app/controllers/overrides/passwords_controller.rb
@@ -26,7 +26,8 @@ module Overrides
                                                   token.client,
                                                   redirect_header_options)
         redirect_to(@resource.build_auth_url(params[:redirect_url],
-                                             redirect_headers))
+                                             redirect_headers),
+                                             redirect_options)
       else
         raise ActionController::RoutingError, 'Not Found'
       end


### PR DESCRIPTION
In Rails 7, it's necessary to add the allow_other_host option when redirecting to an external path. This has also been made possible in Devise Token Auth, where the allow_other_host option can now be set in redirect_to.

https://api.rubyonrails.org/v7.0.4.2/classes/ActionController/Redirecting.html#method-i-redirect_to

> To allow any external redirects pass allow_other_host: true, though using a user-provided param in that case is unsafe.

```ruby
redirect_to "https://rubyonrails.org", allow_other_host: true
```