### PR TITLE
Don't leak information about the existence of accounts in SessionsController

### DIFF
--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -310,23 +310,47 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
     end
 
     describe 'Unconfirmed user' do
-      before do
-        @unconfirmed_user = create(:user)
-        post :create, params: { email: @unconfirmed_user.email,
-                                password: @unconfirmed_user.password }
-        @resource = assigns(:resource)
-        @data = JSON.parse(response.body)
-      end
+      describe 'Without paranoid mode' do
+        before do
+          @unconfirmed_user = create(:user)
+          post :create, params: { email: @unconfirmed_user.email,
+                                  password: @unconfirmed_user.password }
+          @resource = assigns(:resource)
+          @data = JSON.parse(response.body)
+        end
 
-      test 'request should fail' do
-        assert_equal 401, response.status
-      end
+        test 'request should fail' do
+          assert_equal 401, response.status
+        end
 
-      test 'response should contain errors' do
-        assert @data['errors']
-        assert_equal @data['errors'],
-                     [I18n.t('devise_token_auth.sessions.not_confirmed',
-                             email: @unconfirmed_user.email)]
+        test 'response should contain errors' do
+          assert @data['errors']
+          assert_equal @data['errors'],
+                      [I18n.t('devise_token_auth.sessions.not_confirmed',
+                              email: @unconfirmed_user.email)]
+        end
+      end
+      
+      describe 'With paranoid mode' do
+        before do
+          @unconfirmed_user = create(:user)
+          swap Devise, paranoid: true do
+            post :create, params: { email: @unconfirmed_user.email,
+                                    password: @unconfirmed_user.password }
+          end
+          @resource = assigns(:resource)
+          @data = JSON.parse(response.body)
+        end
+
+        test 'request should fail' do
+          assert_equal 401, response.status
+        end
+
+        test 'response should contain errors that do not leak the existence of the account' do
+          assert @data['errors']
+          assert_equal @data['errors'],
+                      [I18n.t('devise_token_auth.sessions.bad_credentials')]
+        end
       end
     end
 
@@ -375,20 +399,42 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
     end
 
     describe 'Non-existing user' do
-      before do
-        post :create,
-             params: { email: -> { Faker::Internet.email },
-                       password: -> { Faker::Number.number(10) } }
-        @resource = assigns(:resource)
-        @data = JSON.parse(response.body)
+      describe 'Without paranoid mode' do
+        before do
+          post :create,
+              params: { email: -> { Faker::Internet.email },
+                        password: -> { Faker::Number.number(10) } }
+          @resource = assigns(:resource)
+          @data = JSON.parse(response.body)
+        end
+
+        test 'request should fail' do
+          assert_equal 401, response.status
+        end
+
+        test 'response should contain errors' do
+          assert @data['errors']
+        end
       end
 
-      test 'request should fail' do
-        assert_equal 401, response.status
-      end
+      describe 'With paranoid mode' do
+        before do
+          mock_hash = '$2a$04$MUWADkfA6MHXDdWHoep6QOvX1o0Y56pNqt3NMWQ9zCRwKSp1HZJba'
+          @bcrypt_mock = MiniTest::Mock.new
+          @bcrypt_mock.expect(:call, mock_hash, [Object, String])
 
-      test 'response should contain errors' do
-        assert @data['errors']
+          swap Devise, paranoid: true do
+            BCrypt::Engine.stub :hash_secret, @bcrypt_mock do
+              post :create,
+                  params: { email: -> { Faker::Internet.email },
+                            password: -> { Faker::Number.number(10) } }
+            end
+          end
+        end
+        
+        test 'password should be hashed' do
+          @bcrypt_mock.verify
+        end
       end
     end
 
@@ -472,21 +518,44 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
       end
 
       describe 'locked user' do
-        before do
-          @locked_user = create(:lockable_user, :locked)
-          post :create,
-               params: { email: @locked_user.email,
-                         password: @locked_user.password }
-          @data = JSON.parse(response.body)
+        describe 'Without paranoid mode' do
+          before do
+            @locked_user = create(:lockable_user, :locked)
+            post :create,
+                params: { email: @locked_user.email,
+                          password: @locked_user.password }
+            @data = JSON.parse(response.body)
+          end
+
+          test 'request should fail' do
+            assert_equal 401, response.status
+          end
+
+          test 'response should contain errors' do
+            assert @data['errors']
+            assert_equal @data['errors'], [I18n.t('devise.mailer.unlock_instructions.account_lock_msg')]
+          end
         end
 
-        test 'request should fail' do
-          assert_equal 401, response.status
-        end
+        describe 'With paranoid mode' do
+          before do
+            @locked_user = create(:lockable_user, :locked)
+            swap Devise, paranoid: true do
+              post :create,
+                  params: { email: @locked_user.email,
+                            password: @locked_user.password }
+            end
+            @data = JSON.parse(response.body)
+          end
 
-        test 'response should contain errors' do
-          assert @data['errors']
-          assert_equal @data['errors'], [I18n.t('devise.mailer.unlock_instructions.account_lock_msg')]
+          test 'request should fail' do
+            assert_equal 401, response.status
+          end
+
+          test 'response should contain errors that do not leak the existence of the account' do
+            assert @data['errors']
+            assert_equal @data['errors'], [I18n.t('devise_token_auth.sessions.bad_credentials')]
+          end
         end
       end
 


### PR DESCRIPTION
The SessionsController leaks information about the existence of accounts even if Devise's paranoid mode is activated. It leaks this information in the following ways:
1. If the resource is not found, the password isn't hashed, resulting in a probably significantly lower response time (given that the cost factor is configured correctly).
2. If an account is locked or not confirmed, the error messages say so.

The pull request fixes these issues by:
1. Hashing the given password if paranoid mode is activated and the resource isn't found.
2. Always responding with "bad credentials" if paranoid mode is activated and the login fails.