### PR TITLE
Support for writing style deprecated in 7.1 and removed in 7.2

### DIFF
--- a/app/models/devise_token_auth/concerns/active_record_support.rb
+++ b/app/models/devise_token_auth/concerns/active_record_support.rb
@@ -2,7 +2,11 @@ module DeviseTokenAuth::Concerns::ActiveRecordSupport
   extend ActiveSupport::Concern
 
   included do
-    serialize :tokens, DeviseTokenAuth::Concerns::TokensSerialization
+    if Rails::VERSION::MAJOR >= 7 && Rails::VERSION::MINOR >= 1
+      serialize :tokens, coder: DeviseTokenAuth::Concerns::TokensSerialization
+    else
+      serialize :tokens, DeviseTokenAuth::Concerns::TokensSerialization
+    end
   end
 
   class_methods do

--- a/devise_token_auth.gemspec
+++ b/devise_token_auth.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_dependency 'rails', '>= 4.2.0', '< 7.1'
+  s.add_dependency 'rails', '>= 4.2.0', '< 7.2'
   s.add_dependency 'devise', '> 3.5.2', '< 5'
   s.add_dependency 'bcrypt', '~> 3.0'
 

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -420,7 +420,7 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
       describe 'With paranoid mode' do
         before do
           mock_hash = '$2a$04$MUWADkfA6MHXDdWHoep6QOvX1o0Y56pNqt3NMWQ9zCRwKSp1HZJba'
-          @bcrypt_mock = MiniTest::Mock.new
+          @bcrypt_mock = Minitest::Mock.new
           @bcrypt_mock.expect(:call, mock_hash, [Object, String])
 
           swap Devise, paranoid: true do


### PR DESCRIPTION
This writing style will be deprecated in 7.1 and will not be available in 7.2.
```ruby
serialize :tokens, DeviseTokenAuth::Concerns::TokensSerialization
```



FYI: https://github.com/rails/rails/blob/bd4996bdfddb3d9c74ec5e91674f9b0c6e1693dc/activerecord/lib/active_record/attribute_methods/serialization.rb#L186C1-L193C42

```ruby
               ActiveRecord.deprecator.warn(<<~MSG)
                Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.
                Please pass the coder as a keyword argument:
                  serialize #{attr_name.inspect}, coder: #{class_name_or_coder}
              MSG
              coder = class_name_or_coder
```

These are the results of local testing.
<img width="1864" alt="スクリーンショット 2023-09-13 19 02 08" src="https://github.com/lynndylanhurley/devise_token_auth/assets/16137809/7d42352f-e379-4f18-9473-33775cb859a8">