### PR TITLE
Faker safe_email -> email

### DIFF
--- a/test/controllers/devise_token_auth/registrations_controller_test.rb
+++ b/test/controllers/devise_token_auth/registrations_controller_test.rb
@@ -505,7 +505,7 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
               # test valid update param
               @resource_class = User
               @new_operating_thetan = 1_000_000
-              @email = Faker::Internet.safe_email
+              @email = Faker::Internet.email
               @request_params = {
                 operating_thetan: @new_operating_thetan,
                 email: @email
@@ -612,7 +612,7 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
               # test valid update param
               @resource_class = User
               @new_operating_thetan = 1_000_000
-              @email = Faker::Internet.safe_email
+              @email = Faker::Internet.email
               @request_params = {
                 operating_thetan: @new_operating_thetan,
                 email: @email
@@ -663,7 +663,7 @@ class DeviseTokenAuth::RegistrationsControllerTest < ActionDispatch::Integration
           before do
             DeviseTokenAuth.check_current_password_before_update = :password
             @new_operating_thetan = 1_000_000
-            @email = Faker::Internet.safe_email
+            @email = Faker::Internet.email
           end
 
           after do

--- a/test/controllers/devise_token_auth/sessions_controller_test.rb
+++ b/test/controllers/devise_token_auth/sessions_controller_test.rb
@@ -420,7 +420,7 @@ class DeviseTokenAuth::SessionsControllerTest < ActionController::TestCase
       describe 'With paranoid mode' do
         before do
           mock_hash = '$2a$04$MUWADkfA6MHXDdWHoep6QOvX1o0Y56pNqt3NMWQ9zCRwKSp1HZJba'
-          @bcrypt_mock = MiniTest::Mock.new
+          @bcrypt_mock = Minitest::Mock.new
           @bcrypt_mock.expect(:call, mock_hash, [Object, String])
 
           swap Devise, paranoid: true do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.unique.safe_email }
+    email { Faker::Internet.unique.email }
     password { Faker::Internet.password }
     provider { 'email' }
 


### PR DESCRIPTION
NOTE: Faker::Internet.safe_email is deprecated; use email instead. It will be removed on or after 2023-10.
FYI: https://github.com/faker-ruby/faker/blob/56a96cc3d54b9249f8062ebf1779deabc4a282f3/lib/faker/default/internet.rb#L87
```ruby
            deprecate :safe_email, :email, 2023, 10
```



The `safe_email` method is deprecated. The `email` method is safe by default.
https://github.com/faker-ruby/faker/pull/2733

This is a local test result.
<img width="1862" alt="スクリーンショット 2023-09-13 19 07 35" src="https://github.com/lynndylanhurley/devise_token_auth/assets/16137809/19e37241-318a-4770-a2fb-61d41e935ca1">



