### PR TITLE
Fixes 'redirect_options' addition for 'redirect_to' in confirmations

### DIFF
--- a/app/controllers/devise_token_auth/confirmations_controller.rb
+++ b/app/controllers/devise_token_auth/confirmations_controller.rb
@@ -27,7 +27,7 @@ module DeviseTokenAuth
         redirect_to(redirect_to_link, redirect_options)
       else
         if redirect_url
-          redirect_to DeviseTokenAuth::Url.generate(redirect_url, account_confirmation_success: false)
+          redirect_to DeviseTokenAuth::Url.generate(redirect_url, account_confirmation_success: false), redirect_options
         else
           raise ActionController::RoutingError, 'Not Found'
         end


### PR DESCRIPTION
In the following PR, `redirect_options` was added. However, there was an omission in the confirmation email section when errors occurred, so I have included it.
https://github.com/lynndylanhurley/devise_token_auth/pull/1599