### PR TITLE
Fix Rails version comparison

### DIFF
--- a/app/models/devise_token_auth/concerns/active_record_support.rb
+++ b/app/models/devise_token_auth/concerns/active_record_support.rb
@@ -2,7 +2,7 @@ module DeviseTokenAuth::Concerns::ActiveRecordSupport
   extend ActiveSupport::Concern
 
   included do
-    if Rails::VERSION::MAJOR >= 7 && Rails::VERSION::MINOR >= 1
+    if Rails.gem_version >= Gem::Version.new("7.1.0.a")
       serialize :tokens, coder: DeviseTokenAuth::Concerns::TokensSerialization
     else
       serialize :tokens, DeviseTokenAuth::Concerns::TokensSerialization


### PR DESCRIPTION
the previous condition would return false for Rails 8.0, when what we actually want is to always return true for versions > 7.1, right?