### PR TITLE
fix: Prevent lock with unsaved changes

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -131,7 +131,7 @@ module DeviseTokenAuth
     end
 
     def create_and_assign_token
-      if @resource.respond_to?(:with_lock)
+      if @resource.respond_to?(:with_lock) && !@resource.changed?
         @resource.with_lock do
           @token = @resource.create_token
           @resource.save!


### PR DESCRIPTION
We are encountering an error on Rails 7 where Devise is changing the `confirmed_at` field in the resource after calling `@resource.active_for_authentication?`, and it prevents it from running the `@resource.with_lock` block.