### PR TITLE
Include reset_password_token in the redirect URL for the password reset flow

### DIFF
--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -56,7 +56,7 @@ module DeviseTokenAuth
             set_token_in_cookie(@resource, token)
           end
 
-          redirect_header_options = { reset_password: true }
+          redirect_header_options = { reset_password: true, reset_password_token: resource_params[:reset_password_token] }
           redirect_headers = build_redirect_headers(token.token,
                                                     token.client,
                                                     redirect_header_options)


### PR DESCRIPTION
This PR addresses an issue where the password reset email link includes `reset_password_token`, but the token is lost in the subsequent redirect URL. Since the final step of resetting the password requires `reset_password_token` as a parameter, users were unable to complete the password reset unless the token was explicitly included in the final URL.

By adding `reset_password_token` to redirect_header_options, the token is preserved in the redirect URL, allowing the user to properly finish the password reset flow.