### PR TITLE
fix: Update method names to devise_will_save_change_to_email?

### DIFF
--- a/app/models/devise_token_auth/concerns/confirmable_support.rb
+++ b/app/models/devise_token_auth/concerns/confirmable_support.rb
@@ -3,7 +3,7 @@ module DeviseTokenAuth::Concerns::ConfirmableSupport
 
   included do
     # Override standard devise `postpone_email_change?` method
-    # for not to use `will_save_change_to_email?` & `email_changed?` methods.
+    # for not to use `devise_will_save_change_to_email?` & `email_changed?` methods.
     def postpone_email_change?
       postpone = self.class.reconfirmable &&
         email_value_in_database != email &&

--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -42,7 +42,7 @@ module DeviseTokenAuth::Concerns::User
     # don't use default devise email validation
     def email_required?; false; end
     def email_changed?; false; end
-    def will_save_change_to_email?; false; end
+    def devise_will_save_change_to_email?; false; end
 
     if DeviseTokenAuth.send_confirmation_email && devise_modules.include?(:confirmable)
       include DeviseTokenAuth::Concerns::ConfirmableSupport


### PR DESCRIPTION
# Changes in this PR
This change updates a method name to align with changes in `devise`.  
The method [`will_save_change_to_email?`](https://github.com/lynndylanhurley/devise_token_auth/blob/v1.2.5/app/models/devise_token_auth/concerns/user.rb#L45) has been renamed to `devise_will_save_change_to_email?`.

# Background
In the `devise` gem, the [`devise_will_save_change_to_email?`](https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/orm.rb#L28-L30) method was introduced as a wrapper around `will_save_change_to_email?` to accommodate changes in dirty tracking.  
As a result, [email validation in devise](https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/models/validatable.rb#L34-L35) has also been updated to use `devise_will_save_change_to_email?`.

For more details, please refer to the following `devise` Pull Request:  
https://github.com/heartcombo/devise/pull/5575

# Impact
There are no behavioral changes introduced by this update.

- `devise_token_auth` [does not use devise's email validation](https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/models/devise_token_auth/concerns/user.rb#L42-L45).
- Internally, `devise_will_save_change_to_email?` simply calls `will_save_change_to_email?`.

I would like to take this opportunity to thank maintainers❤️ 