### PR TITLE
docs: clarify installation steps and Devise dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,39 +17,60 @@ Also, it maintains a session for each client/device, so you can have as many ses
 
 ## Main features
 
-* Seamless integration with:
-  * [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) for [AngularJS](https://github.com/angular/angular.js)
-  * [Angular-Token](https://github.com/neroniaky/angular-token) for [Angular](https://github.com/angular/angular)
-  * [redux-token-auth](https://github.com/kylecorbelli/redux-token-auth) for [React with Redux](https://github.com/reactjs/react-redux)
-  * [jToker](https://github.com/lynndylanhurley/j-toker) for [jQuery](https://jquery.com/)
-  * [vanilla-token-auth](https://github.com/theblang/vanilla-token-auth) for an unopinionated client
-  * [flutter_token_auth](https://github.com/diarmuidr3d/flutter_token_auth) for Flutter
-* Oauth2 authentication using [OmniAuth](https://github.com/intridea/omniauth).
-* Email authentication using [Devise](https://github.com/plataformatec/devise), including:
-  * User registration, update and deletion
-  * Login and logout
-  * Password reset, account confirmation
-* Support for [multiple user models](./docs/usage/multiple_models.md).
-* It is [secure](docs/security.md).
+- Seamless integration with:
+  - [ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) for [AngularJS](https://github.com/angular/angular.js)
+  - [Angular-Token](https://github.com/neroniaky/angular-token) for [Angular](https://github.com/angular/angular)
+  - [redux-token-auth](https://github.com/kylecorbelli/redux-token-auth) for [React with Redux](https://github.com/reactjs/react-redux)
+  - [jToker](https://github.com/lynndylanhurley/j-toker) for [jQuery](https://jquery.com/)
+  - [vanilla-token-auth](https://github.com/theblang/vanilla-token-auth) for an unopinionated client
+  - [flutter_token_auth](https://github.com/diarmuidr3d/flutter_token_auth) for Flutter
+- Oauth2 authentication using [OmniAuth](https://github.com/intridea/omniauth).
+- Email authentication using [Devise](https://github.com/plataformatec/devise), including:
+  - User registration, update and deletion
+  - Login and logout
+  - Password reset, account confirmation
+- Support for [multiple user models](./docs/usage/multiple_models.md).
+- It is [secure](docs/security.md).
 
 This project leverages the following gems:
 
-* [Devise](https://github.com/plataformatec/devise)
-* [OmniAuth](https://github.com/intridea/omniauth)
+- [Devise](https://github.com/plataformatec/devise)
+- [OmniAuth](https://github.com/intridea/omniauth)
 
 ## Installation
 
 Add the following to your `Gemfile`:
 
-~~~ruby
+```ruby
+gem 'devise'
 gem 'devise_token_auth'
-~~~
+```
 
-Then install the gem using bundle:
+Install the gem using bundle:
 
-~~~bash
+```bash
 bundle install
-~~~
+```
+
+Then run standard devise install command. You must install and configure Devise before running the Devise Token Auth installer.
+
+```bash
+rails g devise:install
+```
+
+This command will:
+• Create the file config/initializers/devise.rb with Devise configuration.
+• Add default URL options for the mailer.
+• Provide setup instructions for the development environment.
+
+💡 Even though devise_token_auth is designed for JSON APIs instead of HTML views,
+Devise still requires its initializer to configure mailer URLs, secret keys, and encryption settings.
+
+Example of one-step-install to create devise_token_auth authentication for User model:
+
+```bash
+mount_devise_token_auth_for 'User', at: 'auth'
+```
 
 ## [Docs](https://devise-token-auth.gitbook.io/devise-token-auth)
 
@@ -75,7 +96,6 @@ We have some bounties for some issues, [check them out](https://github.com/lynnd
 
 The fully configured api used in these demos can be found [here](https://github.com/lynndylanhurley/devise_token_auth_demo).
 
-
 ## Contributors
 
 <a href="graphs/contributors"><img src="https://opencollective.com/devise_token_auth/contributors.svg?width=890&button=false" /></a>
@@ -86,7 +106,6 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 [![](https://opencollective.com/devise_token_auth/backers.svg?width=890)](https://opencollective.com/devise_token_auth#backers)
 
-
 ## Sponsors
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/devise_token_auth#sponsor)]
@@ -94,4 +113,5 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 [![](https://opencollective.com/devise_token_auth/sponsor/0/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/0/website) [![](https://opencollective.com/devise_token_auth/sponsor/1/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/1/website) [![](https://opencollective.com/devise_token_auth/sponsor/2/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/2/website) [![](https://opencollective.com/devise_token_auth/sponsor/3/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/3/website) [![](https://opencollective.com/devise_token_auth/sponsor/4/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/4/website) [![](https://opencollective.com/devise_token_auth/sponsor/5/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/5/website) [![](https://opencollective.com/devise_token_auth/sponsor/6/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/6/website) [![](https://opencollective.com/devise_token_auth/sponsor/7/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/7/website) [![](https://opencollective.com/devise_token_auth/sponsor/8/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/8/website) [![](https://opencollective.com/devise_token_auth/sponsor/9/avatar.svg)](https://opencollective.com/devise_token_auth/sponsor/9/website)
 
 ## License
+
 This project uses the WTFPL

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2,48 +2,48 @@
 
 You will need to create a [user model](/docs/usage/model_concerns.md), [define routes](/docs/usage/routes.md), [include concerns](/docs/usage/controller_methods.md), and you may want to alter some of the [default settings](initialization.md) for this gem. Run the following command for an easy one-step installation:
 
-~~~bash
+```bash
 rails g devise_token_auth:install [USER_CLASS] [MOUNT_PATH]
-~~~
+```
 
 or for `Mongoid`
 
-~~~bash
+```bash
 rails g devise_token_auth:install_mongoid [USER_CLASS] [MOUNT_PATH]
-~~~
+```
 
 **Example**:
 
-~~~bash
+```bash
 rails g devise_token_auth:install User auth
-~~~
+```
 
 This generator accepts the following optional arguments:
 
-| Argument | Default | Description |
-|---|---|---|
-| USER_CLASS | `User` | The name of the class to use for user authentication. |
-| MOUNT_PATH | `auth` | The path at which to mount the authentication routes. [Read more](/docs/usage/README.md). |
+| Argument   | Default | Description                                                                               |
+| ---------- | ------- | ----------------------------------------------------------------------------------------- |
+| USER_CLASS | `User`  | The name of the class to use for user authentication.                                     |
+| MOUNT_PATH | `auth`  | The path at which to mount the authentication routes. [Read more](/docs/usage/README.md). |
 
 The following events will take place when using the install generator:
 
-* An initializer will be created at `config/initializers/devise_token_auth.rb`. [Read more](initialization.md).
+- An initializer will be created at `config/initializers/devise_token_auth.rb`. [Read more](initialization.md).
 
-* A model will be created in the `app/models` directory. If the model already exists, a concern (and fields for `Mongoid`) will be included at the file. [Read more](/docs/usage/model_concerns.md).
+- A model will be created in the `app/models` directory. If the model already exists, a concern (and fields for `Mongoid`) will be included at the file. [Read more](/docs/usage/model_concerns.md).
 
-* Routes will be appended to file at `config/routes.rb`. [Read more](/docs/usage/routes.md).
+- Routes will be appended to file at `config/routes.rb`. [Read more](/docs/usage/routes.md).
 
-* A concern will be included by your application controller at `app/controllers/application_controller.rb`. [Read more](/docs/usage/controller_methods.md).
+- A concern will be included by your application controller at `app/controllers/application_controller.rb`. [Read more](/docs/usage/controller_methods.md).
 
-* For `ActiveRecord` a migration file will be created in the `db/migrate` directory. Inspect the migrations file, add additional columns if necessary, and then run the migration:
+- For `ActiveRecord` a migration file will be created in the `db/migrate` directory. Inspect the migrations file, add additional columns if necessary, and then run the migration:
 
-  ~~~bash
+  ```bash
   rake db:migrate
-  ~~~
+  ```
 
 You may also need to configure the following items:
 
-* **OmniAuth providers** when using 3rd party oauth2 authentication. [Read more](omniauth.md).
-* **Cross Origin Request Settings** when using cross-domain clients. [Read more](cors.md).
-* **Email** when using email registration. [Read more](email_auth.md).
-* **Multiple model support** may require additional steps. [Read more](/docs/usage/multiple_models.md).
+- **OmniAuth providers** when using 3rd party oauth2 authentication. [Read more](omniauth.md).
+- **Cross Origin Request Settings** when using cross-domain clients. [Read more](cors.md).
+- **Email** when using email registration. [Read more](email_auth.md).
+- **Multiple model support** may require additional steps. [Read more](/docs/usage/multiple_models.md).

--- a/docs/config/cors.md
+++ b/docs/config/cors.md
@@ -5,7 +5,8 @@ If your API and client live on different domains, you will need to configure you
 The following **dangerous** example will allow cross domain requests from **any** domain. Make sure to whitelist only the needed domains.
 
 ##### Example rack-cors configuration:
-~~~ruby
+
+```ruby
 # gemfile
 gem 'rack-cors', :require => 'rack/cors'
 
@@ -23,7 +24,7 @@ module YourApp
     end
   end
 end
-~~~
+```
 
 Make extra sure that the `Access-Control-Expose-Headers` includes `access-token`, `expiry`, `token-type`, `uid`, and `client` (as is set in the example above by the`:expose` param). If your client experiences erroneous 401 responses, this is likely the cause.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,12 +2,12 @@
 
 Add the following to your `Gemfile`:
 
-~~~ruby
+```ruby
 gem 'devise_token_auth'
-~~~
+```
 
 Then install the gem using bundle:
 
-~~~bash
+```bash
 bundle install
-~~~
+```


### PR DESCRIPTION
### Summary
This PR clarifies the installation instructions for `devise_token_auth`.

### Changes
- Explicitly adds `rails g devise:install` step before running the Devise Token Auth generator.
- Explains why `devise` must be configured first.
- Improves formatting for installation commands (replaces `~~~` with valid markdown fences).
- Aligns examples with the current `devise` and `rails` versions.

### Rationale
New users often skip the `rails g devise:install` step, leading to missing mailer URL configs and initialization errors in API-only apps.  
This update prevents confusion and aligns with Devise’s official installation process.