### PR TITLE
Add support ruby 3.3, 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
           - '3.0'
           - 3.1
           - 3.2
+          - 3.3
+          - 3.4
         gemfile:
           - gemfiles/rails_4_2.gemfile
           - gemfiles/rails_5_0.gemfile
@@ -49,6 +51,16 @@ jobs:
           - ruby: 3.2
             gemfile: gemfiles/rails_7_0.gemfile
           - ruby: 3.2
+            gemfile: gemfiles/rails_7_0_mongoid_7.gemfile
+            devise-token-auth-orm: mongoid
+          - ruby: 3.3
+            gemfile: gemfiles/rails_7_0.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails_7_0_mongoid_7.gemfile
+            devise-token-auth-orm: mongoid
+          - ruby: 3.4
+            gemfile: gemfiles/rails_7_0.gemfile
+          - ruby: 3.4
             gemfile: gemfiles/rails_7_0_mongoid_7.gemfile
             devise-token-auth-orm: mongoid
         exclude:
@@ -89,6 +101,26 @@ jobs:
           - ruby: 3.2
             gemfile: gemfiles/rails_5_2.gemfile
           - ruby: 3.2
+            gemfile: gemfiles/rails_6_0.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails_4_2.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails_5_0.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails_5_1.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails_5_2.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails_6_0.gemfile
+          - ruby: 3.4
+            gemfile: gemfiles/rails_4_2.gemfile
+          - ruby: 3.4
+            gemfile: gemfiles/rails_5_0.gemfile
+          - ruby: 3.4
+            gemfile: gemfiles/rails_5_1.gemfile
+          - ruby: 3.4
+            gemfile: gemfiles/rails_5_2.gemfile
+          - ruby: 3.4
             gemfile: gemfiles/rails_6_0.gemfile
 
     services:


### PR DESCRIPTION
  ## Summary

  This PR adds support for Ruby 3.3 and 3.4 to the test suite.

https://github.com/lynndylanhurley/devise_token_auth/issues/1667

  ## Changes

  - Add Ruby 3.3 and 3.4 to the CI test matrix
  - Add test combinations for Ruby 3.3/3.4 with Rails 7.0 (ActiveRecord)
  - Add test combinations for Ruby 3.3/3.4 with Rails 7.0 + Mongoid 7
  - Exclude incompatible Rails versions (4.2, 5.x, 6.0) from Ruby 3.3/3.4 tests

  ## What this PR does NOT include

  To keep this PR focused and reviewable, the following changes are intentionally **not** included and will be addressed in separate PRs:

  - ❌ Dropping support for older Ruby versions (2.7, 3.0, 3.1)
  - ❌ Dropping support for EOL Rails versions (< 7.2)
  - ❌ Adding support for Rails 7.2, 8.0, 8.1

  ## Testing

  CI will verify that all tests pass with Ruby 3.3 and 3.4 on:
  - Rails 7.0 with SQLite, MySQL, and PostgreSQL
  - Rails 7.0 with Mongoid 7

  ## Related

  This is the first step toward modernizing our supported Ruby/Rails versions. Follow-up PRs will:
  1. Add Rails 8.0 support
  2. Add Rails 8.1 support
  3. Remove EOL versions