### PR TITLE
ci: update CI dependencies (actions, postgres, mongodb)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgresql:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -112,7 +112,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup Bundler 1.x for Rails 4.x
         if: ${{ matrix.gemfile == 'gemfiles/rails_4_2.gemfile' || matrix.gemfile == 'gemfiles/rails_4_2_mongoid_5.gemfile' }}
         run: echo "BUNDLER_VERSION=1.17.3" >> $GITHUB_ENV
@@ -123,7 +123,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           bundler: ${{ env.BUNDLER_VERSION || 'latest' }}
-      - uses: supercharge/mongodb-github-action@1.3.0
+      - uses: supercharge/mongodb-github-action@1.12.1
         if: ${{ matrix.devise-token-auth-orm == 'mongoid' }}
       - name: Setup Database
         run: |


### PR DESCRIPTION
https://github.com/lynndylanhurley/devise_token_auth/issues/1667


Updates CI dependencies:
   - actions/checkout: v3 → v5
     - https://github.com/actions/checkout/releases/tag/v5.0.0
   - mongodb-github-action: 1.3.0 → 1.12.1
     - https://github.com/supercharge/mongodb-github-action
   - PostgreSQL: 14 → 16
     - https://www.postgresql.org/support/versioning/