### PR TITLE
Fix clean_old_tokens purging freshly-created token at device cap

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -261,8 +261,13 @@ module DeviseTokenAuth::Concerns::User
     return if tokens.blank? || !max_client_tokens_exceeded?
 
     # First, remove any tokens with expiry greater than current max allowed lifespan
-    #   this handles the case where token lifespan was reduced and old tokens exist
-    max_lifespan_expiry = Time.now.to_i + DeviseTokenAuth.token_lifespan.to_i
+    #   this handles the case where token lifespan was reduced and old tokens exist.
+    #   The threshold MUST be computed the same way TokenFactory.expiry writes
+    #   expiries — calendar advance (Time.zone.now + lifespan) — otherwise a
+    #   calendar Duration (e.g. 2.months) and its average-seconds form
+    #   (token_lifespan.to_i) disagree by hours, and the freshly minted token
+    #   gets purged out from under the response.
+    max_lifespan_expiry = (Time.zone.now + DeviseTokenAuth.token_lifespan).to_i
     tokens_to_keep = tokens.select do |_cid, v|
       expiry = (v[:expiry] || v['expiry']).to_i
       expiry <= max_lifespan_expiry

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -220,5 +220,32 @@ class UserTest < ActiveSupport::TestCase
       # We should have exactly 2 tokens: the new one and client_3
       assert_equal 2, @resource.tokens.length
     end
+
+    # Regression: with a calendar ActiveSupport::Duration lifespan, the token
+    #   expiry is advanced by calendar (Time.zone.now + 2.months) while the old
+    #   eager purge compared against an average-seconds threshold
+    #   (token_lifespan.to_i). The freshly minted token's expiry sat just past
+    #   that threshold and was silently dropped, leaving a 200 response whose
+    #   advertised access-token no longer existed in user.tokens.
+    test 'keeps the freshly created token at the device cap with a calendar lifespan' do
+      DeviseTokenAuth.max_number_of_devices = 2
+      DeviseTokenAuth.token_lifespan = 2.months
+
+      # Fill the cap with tokens created a few hours ago (calendar expiry).
+      old_time = 4.hours.ago
+      @resource.tokens = {}
+      %w[client_1 client_2].each do |client|
+        @resource.tokens[client] = {
+          'token' => 'x',
+          'expiry' => (old_time + DeviseTokenAuth.token_lifespan).to_i
+        }
+      end
+
+      tok = @resource.create_token
+
+      assert @resource.tokens.key?(tok.client),
+             'Freshly created token must survive clean_old_tokens'
+      assert_equal DeviseTokenAuth.max_number_of_devices, @resource.tokens.length
+    end
   end
 end


### PR DESCRIPTION
#  Fix: clean_old_tokens purges the freshly-created token at the device cap

##  Problem

  A user holding max_number_of_devices tokens signs in successfully (200), but no usable session is created: the response advertises an access-token whose record was silently removed from
  user.tokens, so the next validate_token returns 401. Looks like "login broken for one account only."

  Only triggers when token_lifespan is a calendar Duration (2.months, 1.year, …) — the common config.

##  Root cause

  Two definitions of the same lifespan that disagree:

  - Expiry written (TokenFactory.expiry): (Time.zone.now + lifespan).to_i → calendar advance (e.g. 2.months = 61 days).
  - Purge threshold (clean_old_tokens): Time.now.to_i + token_lifespan.to_i → Duration#to_i = average seconds (month = 30.437 days).

  For 2.months the gap is ~10,908s (~3h). A just-minted token's expiry sits past the threshold and fails expiry <= max_lifespan_expiry, so it's filtered out. Older tokens fall under the
  threshold and survive — only the new login token is lost. clean_old_tokens only runs when over the cap, so the bug only bites at max_number_of_devices.

##  Fix

  Compute the threshold the same way expiries are written:

  max_lifespan_expiry = (Time.zone.now + DeviseTokenAuth.token_lifespan).to_i

  The threshold is computed slightly after the token's expiry within the same request, so threshold >= fresh_expiry always holds → the new token survives. The lifespan-reduction purge it
  was added for still works.

##  Tests

  - Kept both existing purge tests.
  - Added regression: user at max_number_of_devices with a calendar token_lifespan → create_token's returned token is present afterward.